### PR TITLE
(more) stable proposal correction for CDELFI

### DIFF
--- a/delfi/distribution/mixture/BaseMixture.py
+++ b/delfi/distribution/mixture/BaseMixture.py
@@ -111,7 +111,8 @@ class BaseMixture(metaclass=ABCMetaDoc):
         total_del_a = np.sum(self.a[ii])
         del_count = ii.size
 
-        self.n_components -= del_count
+        self.ncomp -= del_count
         self.a = np.delete(self.a, ii)
         self.a += total_del_a / self.n_components
         self.xs = [x for i, x in enumerate(self.xs) if i not in ii]
+        

--- a/delfi/inference/CDELFI.py
+++ b/delfi/inference/CDELFI.py
@@ -182,7 +182,7 @@ class CDELFI(BaseInference):
 
         return logs, trn_datasets, posteriors
 
-    def predict(self, x):
+    def predict(self, x, threshold=0.05):
         """Predict posterior given x
 
         Parameters
@@ -197,6 +197,8 @@ class CDELFI(BaseInference):
             # mog is posterior given proposal prior
             mog = super(CDELFI, self).predict(x)  # via super
 
+            mog.prune_negligible_components(threshold=threshold)
+            
             # compute posterior given prior by analytical division step
             if 'Uniform' in str(type(self.generator.prior)):
                 posterior = mog / self.generator.proposal


### PR DESCRIPTION
currently the CDELFI implementation does not check whether MoG components have zero weight (MoG.a[i]=0 for some component i) before attempting to correct for the proposal. 

Since posterior components with zero weight have virtually unrestricted precision matrices, this poses a risk for the proposal correction, since the correction assumes that each component has at least the precision of the proposal (minus the precision of the prior).  