### PR TITLE
integration of addtional features from mnonnenm/delfi fork 

### DIFF
--- a/delfi/inference/BaseInference.py
+++ b/delfi/inference/BaseInference.py
@@ -60,8 +60,8 @@ class BaseInference(metaclass=ABCMetaDoc):
 
         if 'n_inputs_hidden' in kwargs.keys() and kwargs['n_inputs_hidden']>0:
             assert 'n_inputs' in kwargs.keys()
-        #else:
-        #    kwargs.update({'n_inputs': stats.shape[1:]})   
+        else:
+            kwargs.update({'n_inputs': stats.shape[1:]})   
 
         self.network = NeuralNet(**kwargs)
         self.svi = self.network.svi

--- a/delfi/inference/BaseInference.py
+++ b/delfi/inference/BaseInference.py
@@ -54,10 +54,14 @@ class BaseInference(metaclass=ABCMetaDoc):
         self.reinit_weights = reinit_weights
 
         # generate a sample to get input and output dimensions
-        params, stats = generator.gen(1, skip_feedback=True, verbose=False)
-        kwargs.update({'n_inputs': stats.shape[1:],
-                       'n_outputs': params.shape[1],
+        params, stats, source = generator.gen(1, skip_feedback=True, verbose=False)
+        kwargs.update({'n_outputs': params.shape[1],
                        'seed': self.gen_newseed()})
+
+        if 'n_inputs_hidden' in kwargs.keys() and kwargs['n_inputs_hidden']>0:
+            assert 'n_inputs' in kwargs.keys()
+        #else:
+        #    kwargs.update({'n_inputs': stats.shape[1:]})   
 
         self.network = NeuralNet(**kwargs)
         self.svi = self.network.svi
@@ -79,8 +83,11 @@ class BaseInference(metaclass=ABCMetaDoc):
             self.pilot_run(pilot_samples)
         else:
             # parameters are set such that z-transform has no effect
-            self.stats_mean = np.zeros((stats.shape[1],))
-            self.stats_std = np.ones((stats.shape[1],))
+            self.stats_mean = np.zeros((1,*stats.shape[1:]))
+            self.stats_std = np.ones((1,*stats.shape[1:]))
+
+            print('init mean' , self.stats_mean.shape)
+            print('init  std' , self.stats_std.shape)
 
         # optional: z-transform output for obs (also re-centres x onto obs!)
         self.init_norm = init_norm
@@ -236,6 +243,49 @@ class BaseInference(metaclass=ABCMetaDoc):
         self.conditional_norm(fcv)
 
 
+    def init_single_layer_net(self, trn_data, obs_stats):
+        """ Initializes network with zero hidden layers.
+
+        Without hidden layers, posterior means are linear functions Ax+b,
+        and posterior precisions are exp(Cx + d)**2.
+
+        We can initialize A,b,C,d from a homoscedastic linear fit assuming
+        theta = f(x) = Ax + b + eps, where eps ~ N(0, Sig)
+        and Sig = exp(d)**2, C = 0.
+        We assume diagonal noise covariance Sig. 
+
+        """
+        assert self.network.n_components == 1
+        assert self.network.diag_cov
+        assert np.all(obs_stats==self.stats_mean) # assumes self.centre_on_obs()
+
+        ndim, nstats = self.params_mean.size, self.stats_mean.size
+        th, x, w = trn_data
+        w = w.reshape(-1, 1)
+        wth =  w * th
+
+        # solve means
+        X = np.hstack((np.ones((th.shape[0], 1)), x))
+        ndim, nstats = 3, 13
+        beta = np.linalg.solve( X.T.dot(w * X), X.T.dot(wth))
+        A, b = beta[1:,:], beta[0,:]
+
+        # solve variances
+        Sig = (th.T.dot(wth) - X.dot(beta).T.dot(wth))/th.shape[0]
+
+        C = np.zeros((nstats, ndim**2))
+        d = - np.diag(np.log(np.sqrt(np.diag(Sig)))).reshape(-1)
+
+        aps = self.network.aps
+        names = np.array([aps[i].name for i in range(len(aps))])
+
+        self.network.aps[np.where(names=='means.mW0')[0][0]].set_value(A)
+        self.network.aps[np.where(names=='means.mb0')[0][0]].set_value(b)
+        if 'precisions.mW0' in names:
+            self.network.aps[np.where(names=='precisions.mW0')[0][0]].set_value(C)
+        self.network.aps[np.where(names=='precisions.mb0')[0][0]].set_value(d)
+
+
     def gen(self, n_samples, n_reps=1, prior_mixin=0, verbose=None):
         """Generate from generator and z-transform
 
@@ -249,13 +299,13 @@ class BaseInference(metaclass=ABCMetaDoc):
             If None is passed, will default to self.verbose
         """
         verbose = self.verbose if verbose is None else verbose
-        params, stats = self.generator.gen(n_samples, prior_mixin=prior_mixin, verbose=verbose)
+        params, stats, sources = self.generator.gen(n_samples, prior_mixin=prior_mixin, verbose=verbose)
 
         # z-transform params and stats
         params = (params - self.params_mean) / self.params_std
         stats = (stats - self.stats_mean) / self.stats_std
 
-        return params, stats
+        return params, stats, sources
 
     def gen_newseed(self):
         """Generates a new random seed"""
@@ -269,9 +319,23 @@ class BaseInference(metaclass=ABCMetaDoc):
         """
 
         verbose = '(pilot run) ' if self.verbose else False
-        params, stats = self.generator.gen(n_samples, verbose=verbose)
-        self.stats_mean = np.nanmean(stats, axis=0)
-        self.stats_std = np.nanstd(stats, axis=0)
+        params, stats, sources = self.generator.gen(n_samples, verbose=verbose)
+        if 'n_inputs_hidden' in self.kwargs:
+
+            n_inputs_hidden = self.kwargs['n_inputs_hidden']
+            n_inputs = np.prod(self.kwargs['n_inputs'])
+
+            self.stats_mean = np.zeros((1,n_inputs+n_inputs_hidden))
+            self.stats_std = np.ones((1,n_inputs+n_inputs_hidden))
+
+            # assuming inputs directly to hidden units to come *last* in stats
+            idx = np.arange(n_inputs_hidden) + n_inputs
+
+            self.stats_mean[0,idx] = np.nanmean(stats[:,idx], axis=0)
+            self.stats_std[ 0,idx] = np.nanstd( stats[:,idx], axis=0)
+        else:
+            self.stats_mean = np.nanmean(stats, axis=0).reshape((1, *stats.shape[1:]))
+            self.stats_std = np.nanstd(stats, axis=0).reshape((1, *stats.shape[1:]))
 
     def predict(self, x, deterministic=True):
         """Predict posterior given x

--- a/delfi/inference/Basic.py
+++ b/delfi/inference/Basic.py
@@ -6,8 +6,7 @@ from delfi.neuralnet.loss.regularizer import svi_kl_init, svi_kl_zero
 
 
 class Basic(BaseInference):
-    def __init__(self, generator, obs=None, prior_norm=False, pilot_samples=100,
-                 reg_lambda=0.01, seed=None, verbose=True, **kwargs):
+    def __init__(self, generator, obs=None, reg_lambda=0.01,  **kwargs):
         """Basic inference algorithm
 
         Uses samples from the prior for density estimation LFI. Network can be
@@ -45,9 +44,7 @@ class Basic(BaseInference):
             Dictionary containing theano variables that can be monitored while
             training the neural network.
         """
-        super().__init__(generator, prior_norm=prior_norm,
-                         pilot_samples=pilot_samples, seed=seed,
-                         verbose=verbose, **kwargs)
+        super().__init__(generator, **kwargs)
         self.obs = obs
         self.reg_lambda = reg_lambda
         self.round = 0
@@ -147,6 +144,7 @@ class Basic(BaseInference):
                         monitor=self.monitor_dict_from_names(monitor),
                         **kwargs)
             logs.append(t.train(epochs=epochs, minibatch=minibatch,
+                                n_inputs=self.network.n_inputs,
                                 verbose=verbose, stop_on_nan=stop_on_nan))
             trn_datasets.append(trn_data)
 

--- a/delfi/inference/CDELFI.py
+++ b/delfi/inference/CDELFI.py
@@ -227,9 +227,9 @@ class CDELFI(BaseInference):
         """
         proposal = self.generator.proposal
 
-        if proposal is None or isinstance(proposal, (Uniform,Gaussian)):  
+        if proposal is None or isinstance(proposal, (Uniform,Gaussian)):
             posterior = self._predict_from_Gaussian_prop(self.obs)
-        elif len(self.generator.proposal.xs) <= self.network.n_components:                    
+        elif len(self.generator.proposal.xs) <= self.network.n_components:
             print('correcting for MoG proposal')
             posterior = self._predict_from_MoG_prop(self.obs)
         else:
@@ -277,9 +277,9 @@ class CDELFI(BaseInference):
         missmatch in the prior and proposal prior if the latter is
         given by a Gaussian mixture with multiple mixture components.
 
-        Assumes proposal mixture components are well-separated, which 
-        allows to locally correct each posterior component only for the 
-        closest proposal component. 
+        Assumes proposal mixture components are well-separated, which
+        allows to locally correct each posterior component only for the
+        closest proposal component.
 
         Parameters
         ----------
@@ -314,7 +314,7 @@ class CDELFI(BaseInference):
             # correct mixture coefficients a[i]
 
             # prefactors
-            log_a = np.log(mog.a[i]) - np.log(a_prop) 
+            log_a = np.log(mog.a[i]) - np.log(a_prop)
             # determinants
             log_a += 0.5 * (logdet(c.P)+ldetP0-logdet(c_prop.P)-logdet(c_post.P))
             # Mahalanobis distances
@@ -323,7 +323,7 @@ class CDELFI(BaseInference):
             log_a += 0.5 * c_prop.m.dot(c_prop.Pm)
             log_a += 0.5 * c_post.m.dot(c_post.Pm)
             a_i = np.exp(log_a)
-            
+
             xs_new.append(c_post)
             a_new.append(a_i)
 
@@ -338,10 +338,10 @@ class CDELFI(BaseInference):
         """Predict posterior given x under proposal prior
 
         Predicts the uncorrected posterior associated with the proposal
-        prior (versus the original prior). 
+        prior (versus the original prior).
 
-        Allows to obtain some posterior estimates when the analytical 
-        correction for the proposal prior fails. 
+        Allows to obtain some posterior estimates when the analytical
+        correction for the proposal prior fails.
 
         Parameters
         ----------
@@ -355,21 +355,21 @@ class CDELFI(BaseInference):
         """Split MoG components
 
         Replicates, perturbes and (optionally) standardizes MoG
-        components across rounds. 
+        components across rounds.
 
-        Replica MoG components serve as part of initialization for 
-        MDN in the next round. 
+        Replica MoG components serve as part of initialization for
+        MDN in the next round.
 
         Parameters
         ----------
         standardize : boolean
-            whether to standardize the replicated components 
+            whether to standardize the replicated components
         """
         # define magnitute of (symmetry-breaking) perturbation noise on weights
         eps = 1.0e-2 if standardize else 1.0e-6
 
         if self.kwargs['n_components'] > self.network.n_components:
-            
+
             # get parameters of current network
             old_params = self.network.params_dict.copy()
             old_n_components = self.network.n_components
@@ -402,17 +402,17 @@ class CDELFI(BaseInference):
     def standardize_components(self):
         """Standardize MoG components
 
-        Changes weights in MoG layer of the attached MDN to split the 
+        Changes weights in MoG layer of the attached MDN to split the
         support of a Gaussian proposal prior among multiple MoG components
-        of the posterior estimate. 
+        of the posterior estimate.
 
         Meant to give multi-component MDN initializations that start with
-        more distinguishable components than is achieved through simply 
+        more distinguishable components than is achieved through simply
         replicating components and perturbing them with symmetry-breaking
-        noise.  
+        noise.
 
         """
-        assert isinstance(self.generator.proposal, Gaussian) 
+        assert isinstance(self.generator.proposal, Gaussian)
 
         # grab activation from last hidden layer
         last_hidden = self.network.layer['mixture_weights'].input_layer

--- a/delfi/inference/CDELFI.py
+++ b/delfi/inference/CDELFI.py
@@ -3,14 +3,36 @@ import numpy as np
 import theano.tensor as tt
 
 from delfi.inference.BaseInference import BaseInference
+from delfi.distribution.mixture.BaseMixture import BaseMixture
+from delfi.distribution import Gaussian, Uniform
 from delfi.neuralnet.NeuralNet import NeuralNet
 from delfi.neuralnet.Trainer import Trainer
 from delfi.neuralnet.loss.regularizer import svi_kl_zero
 
+from delfi.utils.sbc import SBC
+
+import lasagne.layers as ll
+import theano
+dtype = theano.config.floatX
+
+def per_round(y):
+
+    if type(y) == list:
+        try:
+            y_round = y[r-1]
+        except:
+            y_round = y[-1]
+    else:
+        y_round = y
+
+    return y_round
+
+def logdet(M):
+    slogdet = np.linalg.slogdet(M)
+    return slogdet[0] * slogdet[1]
 
 class CDELFI(BaseInference):
-    def __init__(self, generator, obs, prior_norm=False, pilot_samples=100,
-                 n_components=1, reg_lambda=0.01, seed=None, verbose=True,
+    def __init__(self, generator, obs, reg_lambda=0.01,
                  **kwargs):
         """Conditional density estimation likelihood-free inference (CDE-LFI)
 
@@ -29,8 +51,6 @@ class CDELFI(BaseInference):
             samples is run. The mean and std of the summary statistics of the
             pilot samples will be subsequently used to z-transform summary
             statistics.
-        n_components : int
-            Number of components in final round (PM's algorithm 2)
         reg_lambda : float
             Precision parameter for weight regularizer if svi is True
         seed : int or None
@@ -51,19 +71,20 @@ class CDELFI(BaseInference):
             training the neural network.
         """
         # Algorithm 1 of PM requires a single component
-        kwargs.update({'n_components': 1})
+        #if 'n_components' in kwargs:
+        #    assert kwargs['n_components'] == 1 # moved n_components argument to run()
 
-        super().__init__(generator, prior_norm=prior_norm,
-                         pilot_samples=pilot_samples, seed=seed,
-                         verbose=verbose, **kwargs)
-
-        self.n_components = n_components
         self.obs = obs
-    
+
+        super().__init__(generator, **kwargs)
+
+        self.init_fcv = 0.8 # CDELFI won't call conditional_norm() with single component
+
         if np.any(np.isnan(self.obs)):
             raise ValueError("Observed data contains NaNs")
 
         self.reg_lambda = reg_lambda
+        self.round = 0 # total round counter
 
     def loss(self, N):
         """Loss function for training
@@ -76,8 +97,13 @@ class CDELFI(BaseInference):
         loss = -tt.mean(self.network.lprobs)
 
         if self.svi:
-            kl, imvs = svi_kl_zero(self.network.mps, self.network.sps,
-                                   self.reg_lambda)
+
+            if self.reg_lambda > 0:
+                kl, imvs = svi_kl_zero(self.network.mps, self.network.sps,
+                                       self.reg_lambda)
+            else:
+                kl, imvs = 0, {}
+
             loss = loss + 1 / N * kl
 
             # adding nodes to dict s.t. they can be monitored
@@ -87,7 +113,9 @@ class CDELFI(BaseInference):
         return loss
 
     def run(self, n_train=100, n_rounds=2, epochs=100, minibatch=50,
-            monitor=None, **kwargs):
+            monitor=None, n_components=1, stndrd_comps=False,
+            project_proposal=False, sbc_fun = None,
+            **kwargs):
         """Run algorithm
 
         Parameters
@@ -107,6 +135,8 @@ class CDELFI(BaseInference):
             Names of variables to record during training along with the value
             of the loss function. The observables attribute contains all
             possible variables that can be monitored
+        n_components : int
+            Number of components in final round (if > 1, gives PM's algorithm 2)
         kwargs : additional keyword arguments
             Additional arguments for the Trainer instance
 
@@ -123,72 +153,103 @@ class CDELFI(BaseInference):
         trn_datasets = []
         posteriors = []
 
+        #assert self.kwargs['n_components'] == 1
+        # could also allow to go back to single Gaussian via project_to_gaussian()
+
         for r in range(1, n_rounds + 1):  # start at 1
-            # if round > 1, set new proposal distribution before sampling
-            if r > 1:
+
+            self.round += 1
+
+            if self.round > 1:
                 # posterior becomes new proposal prior
-                posterior = self.predict(self.obs)
-                self.generator.proposal = posterior.project_to_gaussian()
+                proposal = self.predict(self.obs)
+                if isinstance(proposal, BaseMixture) and (len(proposal.xs)==1 or project_proposal):
+                    proposal = proposal.project_to_gaussian()
+                self.generator.proposal = proposal
 
             # number of training examples for this round
-            if type(n_train) == list:
-                try:
-                    n_train_round = n_train[r-1]
-                except:
-                    n_train_round = n_train[-1]
-            else:
-                n_train_round = n_train
+            epochs_round = per_round(epochs)
+            n_train_round = per_round(n_train)
 
             # draw training data (z-transformed params and stats)
-            verbose = '(round {}) '.format(r) if self.verbose else False
-            trn_data = self.gen(n_train_round, verbose=verbose)
+            verbose = '(round {}) '.format(self.round) if self.verbose else False
+            trn_data = self.gen(n_train_round, verbose=verbose)[:2]
 
-            # algorithm 2 of Papamakarios and Murray
-            if r == n_rounds and self.n_components > 1:
-                # get parameters of current network
-                old_params = self.network.params_dict.copy()
+            if r == n_rounds:
+                self.kwargs.update({'n_components': n_components})
+                self.split_components(standardize=stndrd_comps)
 
-                # create new network
-                network_spec = self.network.spec_dict.copy()
-                network_spec.update({'n_components': self.n_components})
-                self.network = NeuralNet(**network_spec)
-                new_params = self.network.params_dict
+            if r > 1:
+                self.reinit_network() # reinits network if flag is set
 
-                # set weights of new network
-                # weights of additional components are duplicates
-                for p in [s for s in new_params if 'means' in s or
-                          'precisions' in s]:
-                    new_params[p] = old_params[p[:-1] + '0']
-                    new_params[p] += 1.0e-6*self.rng.randn(*new_params[p].shape)
 
-                self.network.params_dict = new_params
-
-            trn_inputs = [self.network.params, self.network.stats]
+            if hasattr(self.network, 'extra_stats'):
+                trn_inputs = [self.network.params, self.network.stats, self.network.extra_stats]
+            else:
+                trn_inputs = [self.network.params, self.network.stats]
 
             t = Trainer(self.network, self.loss(N=n_train_round),
                         trn_data=trn_data, trn_inputs=trn_inputs,
                         monitor=self.monitor_dict_from_names(monitor),
                         seed=self.gen_newseed(), **kwargs)
-            logs.append(t.train(epochs=epochs, minibatch=minibatch,
-                                verbose=verbose))
+            logs.append(t.train(epochs=epochs_round, minibatch=minibatch,
+                                verbose=verbose,n_inputs=self.network.n_inputs,
+                                n_inputs_hidden=self.network.n_inputs_hidden))
             trn_datasets.append(trn_data)
 
             try:
                 posteriors.append(self.predict(self.obs))
             except:
                 posteriors.append(None)
-                print('analytic correction for proposal seemingly failed!')
+                print('analytical correction broke !')
                 break
+
+
+            if not sbc_fun is None:
+                print('computing simulation-based calibration')
+                sbc = SBC(generator=self.generator, inf=self, f=sbc_fun)
+                data = (trn_data[0]*self.params_std+self.params_mean,
+                        trn_data[1])
+                logs[-1]['sbc'] = sbc.test(N=None, L=100, data=data)
 
         return logs, trn_datasets, posteriors
 
-    def predict(self, x, threshold=0.05):
+
+    def predict(self, x, threhold=0.01):
         """Predict posterior given x
 
         Parameters
         ----------
         x : array
             Stats for which to compute the posterior
+        threshold: float
+            Threshold for pruning MoG components (percent of posterior mass)
+        """
+        proposal = self.generator.proposal
+
+        if proposal is None or isinstance(proposal, (Uniform,Gaussian)):  
+            posterior = self._predict_from_Gaussian_prop(self.obs)
+        elif len(self.generator.proposal.xs) <= self.network.n_components:                    
+            print('correcting for MoG proposal')
+            posterior = self._predict_from_MoG_prop(self.obs)
+        else:
+            raise NotImplementedError
+
+        return posterior
+
+    def _predict_from_Gaussian_prop(self, x, threshold=0.01):
+        """Predict posterior given x
+
+        Predicts posteriors from the attached MDN and corrects for
+        missmatch in the prior and proposal prior if the latter is
+        given by a Gaussian object.
+
+        Parameters
+        ----------
+        x : array
+            Stats for which to compute the posterior
+        threshold: float
+            Threshold for pruning MoG components (percent of posterior mass)
         """
         if self.generator.proposal is None:
             # no correction necessary
@@ -196,9 +257,8 @@ class CDELFI(BaseInference):
         else:
             # mog is posterior given proposal prior
             mog = super(CDELFI, self).predict(x)  # via super
-
             mog.prune_negligible_components(threshold=threshold)
-            
+
             # compute posterior given prior by analytical division step
             if 'Uniform' in str(type(self.generator.prior)):
                 posterior = mog / self.generator.proposal
@@ -209,3 +269,169 @@ class CDELFI(BaseInference):
                 raise NotImplemented
 
             return posterior
+
+    def _predict_from_MoG_prop(self, x, threshold=0.01):
+        """Predict posterior given x
+
+        Predicts posteriors from the attached MDN and corrects for
+        missmatch in the prior and proposal prior if the latter is
+        given by a Gaussian mixture with multiple mixture components.
+
+        Assumes proposal mixture components are well-separated, which 
+        allows to locally correct each posterior component only for the 
+        closest proposal component. 
+
+        Parameters
+        ----------
+        x : array
+            Stats for which to compute the posterior
+        threshold: float
+            Threshold for pruning MoG components (percent of posterior mass)
+        """
+        # mog is posterior given proposal prior
+        mog = super(CDELFI, self).predict(x)  # via super
+        mog.prune_negligible_components(threshold=threshold)
+
+        prop  = self.generator.proposal
+        prior = self.generator.prior
+        ldetP0, d0  = logdet(prior.P), prior.m.dot(prior.Pm)
+        means = np.vstack([c.m for c in prop.xs])
+
+        xs_new, a_new = [], []
+        for c in mog.xs:
+
+            # greedily pairing proposal and posterior components by means
+            # (should probably at least use Mahalanobis distance)
+            dists = np.sum( (means - np.atleast_2d(c.m))**2, axis=1)
+            i = np.argmin(dists)
+
+            c_prop = prop.xs[i]
+            a_prop = prop.a[i]
+
+            # correct means and covariances of individual proposals
+            c_post = (c * prior) / c_prop
+
+            # correct mixture coefficients a[i]
+
+            # prefactors
+            log_a = np.log(mog.a[i]) - np.log(a_prop) 
+            # determinants
+            log_a += 0.5 * (logdet(c.P)+ldetP0-logdet(c_prop.P)-logdet(c_post.P))
+            # Mahalanobis distances
+            log_a -= 0.5 * c.m.dot(c.Pm)
+            log_a -= 0.5 * d0
+            log_a += 0.5 * c_prop.m.dot(c_prop.Pm)
+            log_a += 0.5 * c_post.m.dot(c_post.Pm)
+            a_i = np.exp(log_a)
+            
+            xs_new.append(c_post)
+            a_new.append(a_i)
+
+        a_new = np.array(a_new)
+        # alpha defined only up to \tilde{p}(x) / p(x), i.e. need to normalize
+        a_new /= a_new.sum()
+
+        return dd.MoG( xs = xs_new, a = a_new )
+
+
+    def predict_uncorrected(self, x):
+        """Predict posterior given x under proposal prior
+
+        Predicts the uncorrected posterior associated with the proposal
+        prior (versus the original prior). 
+
+        Allows to obtain some posterior estimates when the analytical 
+        correction for the proposal prior fails. 
+
+        Parameters
+        ----------
+        x : array
+            Stats for which to compute the posterior
+        """
+
+        return super(CDELFI, self).predict(x)  # via super
+
+    def split_components(self, standardize=False):
+        """Split MoG components
+
+        Replicates, perturbes and (optionally) standardizes MoG
+        components across rounds. 
+
+        Replica MoG components serve as part of initialization for 
+        MDN in the next round. 
+
+        Parameters
+        ----------
+        standardize : boolean
+            whether to standardize the replicated components 
+        """
+        # define magnitute of (symmetry-breaking) perturbation noise on weights
+        eps = 1.0e-2 if standardize else 1.0e-6
+
+        if self.kwargs['n_components'] > self.network.n_components:
+            
+            # get parameters of current network
+            old_params = self.network.params_dict.copy()
+            old_n_components = self.network.n_components
+
+            # create new network
+            self.network = NeuralNet(**self.kwargs)
+            new_params = self.network.params_dict
+
+            # set weights of new network
+            comps_new = [s for s in new_params if 'means' in s or
+                      'precisions' in s]
+
+            # weights of additional components are duplicates
+            for p in np.sort(comps_new):
+                i = int(float(p[-1]))%old_n_components
+                # WARNING: this assumes there is less <10 old components!
+                old_params[p] = old_params[p[:-1] + str(i)].copy()
+                old_params[p] += eps*self.rng.randn(*new_params[p].shape)
+
+            # assert mixture coefficients are alpha_k = 1/n_components)
+            old_params['weights.mW'] = 0. * new_params['weights.mW']
+            old_params['weights.mb'] = 0. * new_params['weights.mb']
+
+            self.network.params_dict = old_params
+
+            if standardize:
+                self.standardize_components()
+
+
+    def standardize_components(self):
+        """Standardize MoG components
+
+        Changes weights in MoG layer of the attached MDN to split the 
+        support of a Gaussian proposal prior among multiple MoG components
+        of the posterior estimate. 
+
+        Meant to give multi-component MDN initializations that start with
+        more distinguishable components than is achieved through simply 
+        replicating components and perturbing them with symmetry-breaking
+        noise.  
+
+        """
+        assert isinstance(self.generator.proposal, Gaussian) 
+
+        # grab activation from last hidden layer
+        last_hidden = self.network.layer['mixture_weights'].input_layer
+        h = theano.function(
+            inputs=[self.network.stats, self.network.extra_stats],
+            outputs=[ll.get_output(last_hidden)])
+
+        n, d = self.network.n_inputs_hidden, self.network.n_inputs
+        stats = (self.obs-self.stats_mean)/self.stats_std
+        if n > 0:
+            input_stats = [stats[:,:-n].reshape(-1,*d).astype(dtype),
+                           stats[:,-n:].astype(dtype)]
+        else: 
+            input_stats = stats.reshape(-1, *d).astype(dtype)
+
+        # target variance and (z-scored) mean from proposal
+        proposal = self.generator.proposal
+
+        self.conditional_norm(fcv=self.init_fcv,
+                              tmu=(proposal.m-self.params_mean)/self.params_std,
+                              tSig=proposal.S,
+                              h=h(*input_stats)[0].flatten())

--- a/delfi/inference/SLPE.py
+++ b/delfi/inference/SLPE.py
@@ -1,0 +1,296 @@
+import numpy as np
+import theano
+import theano.tensor as tt
+
+from delfi.inference.BaseInference import BaseInference
+from delfi.neuralnet.Trainer import Trainer
+from delfi.neuralnet.LinearNet import LinearNet
+from delfi.kernel.Kernel_learning import kernel_opt
+from delfi.kernel.ImproperFlat import ImproperFlat
+from delfi.kernel.BaseKernel import BaseKernel
+from delfi.kernel.Gauss import Gauss
+from delfi.kernel.Uniform import Uniform
+from delfi.kernel.Epanechnikov import Epanechnikov
+
+from delfi.neuralnet.LinearNet import LinearNet
+
+
+dtype = theano.config.floatX
+
+
+class SLPE(BaseInference):
+    def __init__(self, generator, obs, prior_norm=False,
+                 pilot_samples=100, convert_to_T=None, centre_on_obs=True,
+                 reg_lambda=0.01, prior_mixin=0., seed=None, verbose=True, cbkrnl=None,
+                 reinit_weights=False, **kwargs):
+        """Sequential linear posterior estimation (SLPE)
+
+        Parameters
+        ----------
+        generator : generator instance
+            Generator instance
+        obs : array
+            Observation in the format the generator returns (1 x n_summary)
+        prior_norm : bool
+            If set to True, will z-transform params based on mean/std of prior
+        pilot_samples : None or int
+            If an integer is provided, a pilot run with the given number of
+            samples is run. The mean and std of the summary statistics of the
+            pilot samples will be subsequently used to z-transform summary
+            statistics.
+        convert_to_T : None or int
+            Convert proposal distribution to Student's T? If a number if given,
+            the number specifies the degrees of freedom. None for no conversion
+        reg_lambda : float
+            Precision parameter for weight regularizer if svi is True
+        prior_mixin : float
+            Percentage of the prior mixed into the proposal prior. While training,
+            an additional prior_mixin * N samples will be drawn from the actual prior
+            in each round            
+        seed : int or None
+            If provided, random number generator will be seeded
+        verbose : bool
+            Controls whether or not progressbars are shown
+        kwargs : additional keyword arguments
+            Additional arguments for the NeuralNet instance, including:
+                n_components : int
+                    Number of components of the mixture density
+                n_hiddens : list of ints
+                    Number of hidden units per layer of the neural network
+                svi : bool
+                    Whether to use SVI version of the network or not
+        cbkrnl: calibration kernel
+
+        Attributes
+        ----------
+        observables : dict
+            Dictionary containing theano variables that can be monitored while
+            training the neural network.
+        """
+        assert centre_on_obs # not meaningful otherwise. Change at own risk!
+
+        self.seed = seed
+        if seed is not None:
+            self.rng = np.random.RandomState(seed=seed)
+        else:
+            self.rng = np.random.RandomState()
+        self.verbose = verbose
+
+        # bind generator, reset proposal attribute
+        self.generator = generator
+
+        # generate a sample to get input and output dimensions
+        params, stats, _ = generator.gen(1, skip_feedback=True, verbose=False)
+        kwargs.update({'n_inputs': stats.shape[1],
+                       'n_outputs': params.shape[1],
+                       'seed': self.gen_newseed()})
+
+        self.network = LinearNet(**kwargs)
+        self.kwargs = kwargs
+
+        # parameters for z-transform of params
+        if prior_norm:
+            # z-transform for params based on prior
+            self.params_mean = self.generator.prior.mean
+            self.params_std = self.generator.prior.std
+        else:
+            # parameters are set such that z-transform has no effect
+            self.params_mean = np.zeros((params.shape[1],))
+            self.params_std = np.ones((params.shape[1],))
+
+        # parameters for z-transform for stats
+        if pilot_samples is not None and pilot_samples != 0:
+            # determine via pilot run
+            self.pilot_run(pilot_samples)
+        else:
+            # parameters are set such that z-transform has no effect
+            self.stats_mean = np.zeros((stats.shape[1],))
+            self.stats_std = np.ones((stats.shape[1],))
+
+        self.obs = obs
+        if centre_on_obs: 
+            self.centre_on_obs()
+        self.obz = self.standardize_stats(self.obs)
+
+        self.round = 0
+        self.convert_to_T = convert_to_T
+        self.prior_mixin = 0. if prior_mixin is None else prior_mixin
+
+        if cbkrnl is None: 
+            self.cbkrnl = ImproperFlat(self.obz) 
+        elif issubclass(cbkrnl, BaseKernel):
+            self.cbkrnl = cbkrnl
+        else:
+            raise NotImplementedError
+
+    def run(self, n_train=100, n_rounds=2, 
+            kernel_loss=None, stop_on_nan=False,
+            epochs_cbk=None, cbk_feature_layer=0, minibatch_cbk=None, 
+            reg_lambdas=None, cbk_delta=None, naive_weights=False, **kwargs):
+        """Run algorithm
+
+        Parameters
+        ----------
+        n_train : int or list of ints
+            Number of data points drawn per round. If a list is passed, the
+            nth list element specifies the number of training examples in the
+            nth round. If there are fewer list elements than rounds, the last
+            list element is used.
+        n_rounds : int
+            Number of rounds
+        epochs : int
+            Number of epochs used for neural network training
+        minibatch : int
+            Size of the minibatches used for neural network training
+        monitor : list of str
+            Names of variables to record during training along with the value
+            of the loss function. The observables attribute contains all
+            possible variables that can be monitored
+        round_cl : int
+            Round after which to start continual learning
+        stop_on_nan : bool
+            If True, will halt if NaNs in the loss are encountered
+        kwargs : additional keyword arguments
+            Additional arguments for the Trainer instance
+
+        Returns
+        -------
+        logs : list of dicts
+            Dictionaries contain information logged while training the networks
+        trn_datasets : list of (params, stats)
+            training datasets, z-transformed
+        posteriors : list of distributions
+            posterior after each round
+        """
+        logs = []
+        trn_datasets = []
+        posteriors = []
+
+        for r in range(n_rounds):
+            self.round += 1
+
+            # if round > 1, set new proposal distribution before sampling
+            if self.round > 1:
+                # posterior becomes new proposal prior
+                proposal = self.predict(self.obs)  # see super
+
+                # convert proposal to student's T?
+                if self.convert_to_T is not None:
+                    if type(self.convert_to_T) == int:
+                        dofs = self.convert_to_T
+                    else:
+                        dofs = 10
+                    proposal = proposal.convert_to_T(dofs=dofs)
+
+                self.generator.proposal = proposal
+
+            # number of training examples for this round
+            if type(n_train) == list:
+                try:
+                    n_train_round = n_train[self.round-1]
+                except:
+                    n_train_round = n_train[-1]
+            else:
+                n_train_round = n_train
+
+            if type(epochs_cbk) == list:
+                try:
+                    epochs_cbk_round = epochs_cbk[self.round-1]
+                except:
+                    epochs_cbk_round = epochs_cbk[-1]
+            else:
+                epochs_cbk_round = epochs_cbk
+
+            # draw training data (z-transformed params and stats)
+            verbose = '(round {}) '.format(self.round) if self.verbose else False
+            trn_data = self.gen(n_train_round, prior_mixin=self.prior_mixin, verbose=verbose)
+            n_train_round = trn_data[0].shape[0]
+
+            # precompute importance weights
+            iws = np.ones((n_train_round,))
+
+            cbkrnl, cbl = None, None
+            idx_proposal = np.where(trn_data[2])[0]
+
+            if not minibatch_cbk is None:
+                minibatch_cbk = np.min((minibatch_cbk, idx_proposal.size))
+
+            fstats = trn_data[1][idx_proposal,:].reshape(idx_proposal.size,-1)
+            fobs_z = self.standardize_stats(self.obs).reshape(1,-1)
+
+            if self.round==1 and cbk_delta is not None:
+                print('setting initial kernel')
+                delta = self.get_kernelwidth(cbk_delta, trn_data)
+                self.cbkrnl = Uniform(self.obz.reshape(1,-1), spherical=True, bandwidth=delta)
+
+
+            if self.generator.proposal is not None:
+                params = self.params_std * trn_data[0] + self.params_mean
+                p_prior = self.generator.prior.eval(params, log=False)
+                p_proposal = self.generator.proposal.eval(params, log=False)
+                iws *= p_prior / (self.prior_mixin * p_prior + (1. - self.prior_mixin) * p_proposal)
+
+                # train calibration kernel (learns own normalization)
+                if not kernel_loss is None:
+                    if verbose:
+                        print('fitting calibration kernel ...')
+
+                    cbkrnl, cbl = kernel_opt(
+                        iws=iws[idx_proposal].astype(np.float32), 
+                        stats=fstats,
+                        obs=fobs_z, 
+                        kernel_loss=kernel_loss, 
+                        epochs=epochs_cbk_round,
+                        minibatch=minibatch_cbk,
+                        stop_on_nan=stop_on_nan,
+                        seed=self.gen_newseed(), 
+                        **kwargs)
+                    if verbose: 
+                        print('done.')
+
+                    self.cbkrnl = cbkrnl
+            fstats = trn_data[1].reshape(n_train_round,-1)                    
+            iws *= self.cbkrnl.eval(fstats)
+
+            if naive_weights:
+                iws = np.ones((n_train_round,))            
+
+            logs.append({'cbkrnl' : self.cbkrnl, 'cbk_loss' : cbl})
+
+            # normalize weights
+            iws = (iws/np.sum(iws))*n_train_round
+            trn_data = (trn_data[0], trn_data[1], iws)
+            trn_datasets.append(trn_data)
+
+            self.network.fit(trn_data, self.obz)
+
+            posteriors.append(self.predict(self.obs))
+
+        return logs, trn_datasets, posteriors
+
+
+    def standardize_stats(self, x):
+
+        return (x - self.stats_mean) / self.stats_std
+
+    def predict(self, x):
+        """Predict posterior given x
+
+        Parameters
+        ----------
+        x : array
+            Stats for which to compute the posterior
+        """
+        x_zt = self.standardize_stats(x)
+        posterior = self.network.get_mog(x_zt)
+        return posterior.ztrans_inv(self.params_mean, self.params_std)
+
+    def get_kernelwidth(self, pdelta, trn_data):
+
+        assert pdelta <= 1.
+
+        dx = trn_data[1] - self.obz
+        dist = np.sqrt(np.sum( dx**2, axis=1 ))
+        idx = np.argsort( dist )[int(dist.size*pdelta)]        
+
+        return dist[idx]

--- a/delfi/inference/SNPE.py
+++ b/delfi/inference/SNPE.py
@@ -5,8 +5,8 @@ from delfi.neuralnet.Trainer import Trainer
 from delfi.neuralnet.loss.regularizer import svi_kl_init, svi_kl_zero
 
 class SNPE(BaseInference):
-    def __init__(self, generator, obs, prior_norm=False, pilot_samples=100,
-                 convert_to_T=3, reg_lambda=0.01, prior_mixin=0, kernel=None, seed=None, verbose=True,
+    def __init__(self, generator, obs,
+                 convert_to_T=3, reg_lambda=0.01, prior_mixin=0, kernel=None,
                  **kwargs):
         """Sequential neural posterior estimation (SNPE)
 
@@ -51,9 +51,7 @@ class SNPE(BaseInference):
             Dictionary containing theano variables that can be monitored while
             training the neural network.
         """
-        super().__init__(generator, prior_norm=prior_norm,
-                         pilot_samples=pilot_samples, seed=seed,
-                         verbose=verbose, **kwargs)
+        super().__init__(generator, **kwargs)
         self.obs = np.asarray(obs)
 
         if np.any(np.isnan(self.obs)):
@@ -208,6 +206,7 @@ class SNPE(BaseInference):
                         monitor=self.monitor_dict_from_names(monitor),
                         **kwargs)
             logs.append(t.train(epochs=epochs, minibatch=minibatch,
+                                n_inputs=self.network.n_inputs,
                                 verbose=verbose, stop_on_nan=stop_on_nan))
 
             trn_datasets.append(trn_data)

--- a/delfi/inference/__init__.py
+++ b/delfi/inference/__init__.py
@@ -1,4 +1,4 @@
 from delfi.inference.Basic import Basic
 from delfi.inference.CDELFI import CDELFI
 from delfi.inference.SNPE import SNPE
-from delfi.inference.kSNPE import kSNPE
+from delfi.inference.SLPE import SLPE

--- a/delfi/kernel/Kernel_learning.py
+++ b/delfi/kernel/Kernel_learning.py
@@ -103,7 +103,7 @@ class My_Helper_Kernel(metaclass=ABCMetaDoc):
 
         Returns
         -------
-        weights : N
+        weights : N x 1
             normalized to be 1. for x = obs
         """
         assert x.shape[0] >= 1, 'x.shape[0] needs to be >= 1'
@@ -121,7 +121,7 @@ class My_Helper_Kernel(metaclass=ABCMetaDoc):
 def kernel_opt(iws, stats, obs, kernel_loss=None, step=lu.adam,
                epochs=100, minibatch=100, lr=0.001, lr_decay=1.0, 
                max_norm=0.1, monitor=None, monitor_every=None, 
-               stop_on_nan=False, verbose=False, seed=None):
+               stop_on_nan=False, verbose=False, seed=None, **kwargs):
 
     assert kernel_loss in (None, 'x_kl', 'ess')
 
@@ -161,6 +161,7 @@ def kernel_opt(iws, stats, obs, kernel_loss=None, step=lu.adam,
                    monitor=monitor, seed=seed)
 
     logs = trnr.train(epochs=epochs,
+               n_inputs=[],
                minibatch=minibatch,
                monitor_every=monitor_every,
                stop_on_nan=stop_on_nan,

--- a/delfi/neuralnet/LinearNet.py
+++ b/delfi/neuralnet/LinearNet.py
@@ -1,0 +1,168 @@
+import collections
+import delfi.distribution as dd
+import delfi.neuralnet.layers as dl
+import lasagne
+import lasagne.layers as ll
+import lasagne.nonlinearities as lnl
+import numpy as np
+import theano
+import theano.tensor as tt
+
+from delfi.utils.odict import first, last, nth
+
+dtype = theano.config.floatX
+
+def MyLogSumExp(x, axis=None):
+    x_max = tt.max(x, axis=axis, keepdims=True)
+    return tt.log(tt.sum(tt.exp(x - x_max), axis=axis, keepdims=True)) + x_max
+
+class LinearNet(object):
+    def __init__(self, n_inputs, n_outputs, n_components=1, 
+                 seed=None, svi=True, diag_cov=False):
+        """Initialize a linear-affine density model with homoscedastic noise
+
+        Assumes that the input data (summary statistics) are centered on obs_stats,
+        i.e. it fits only differences x - xo
+
+        Parameters
+        ----------
+        n_inputs : int or tuple of ints or list of ints
+            Dimensionality of input
+        n_outputs : int
+            Dimensionality of output
+        n_components : int
+            Number of components of the mixture density
+        n_filters : list of ints
+            Number of filters  per convolutional layer
+        n_hiddens : list of ints
+            Number of hidden units per fully connected layer
+        n_rnn : None or int
+            Number of RNN units
+        impute_missing : bool
+            If set to True, learns replacement value for NaNs, otherwise those
+            inputs are set to zero
+        seed : int or None
+            If provided, random number generator will be seeded
+        svi : bool
+            Whether to use SVI version or not
+        """
+
+        assert n_components == 1
+        self.n_components = n_components
+
+        self.diag_cov = diag_cov
+        self.n_outputs = n_outputs
+
+        self.svi = svi # not used atm
+
+        self.iws = tt.vector('iws', dtype=dtype)
+
+        self.seed = seed
+        if seed is not None:
+            self.rng = np.random.RandomState(seed=seed)
+        else:
+            self.rng = np.random.RandomState()
+
+        self.params_dict_ = {
+
+        'means.mW0' : np.zeros((n_inputs, n_outputs)),
+        'means.mb0' : np.zeros((n_outputs)),
+
+        'precisions.mW0' : np.zeros((n_inputs, n_outputs**2)),
+        'precisions.mb0' : np.zeros((n_outputs))
+
+        }
+
+
+    def fit(self, trn_data, obs_stats):
+        """ Initializes network with zero hidden layers.
+
+        Without hidden layers, posterior means are linear functions Ax+b,
+        and posterior precisions are exp(Cx + d)**2.
+
+        We can initialize A,b,C,d from a homoscedastic linear fit assuming
+        theta = f(x) = Ax + b + eps, where eps ~ N(0, Sig)
+        and Sig = exp(d)**2, C = 0.
+        We assume diagonal noise covariance Sig. 
+
+        """
+        assert self.n_components == 1
+        assert self.diag_cov
+
+        th, x, w = trn_data
+        w = w.reshape(-1, 1)
+        wth =  w * th
+
+        # solve means
+        X = np.hstack((np.ones((th.shape[0], 1)), x))
+        beta = np.linalg.solve( X.T.dot(w * X), X.T.dot(wth))
+        self.params_dict_['means.mW0'], self.params_dict_['means.mb0'] = beta[1:,:], beta[0,:]
+
+        # solve variances
+        Sig = (th.T.dot(wth) - X.dot(beta).T.dot(wth))/th.shape[0]
+
+        self.params_dict_['precisions.mW0'] = np.zeros_like(self.params_dict['precisions.mW0'])
+        self.params_dict_['precisions.mb0'] = - np.diag(np.log(np.sqrt(np.diag(Sig)))).reshape(-1)
+
+
+    def get_mog(self, stats, deterministic=True):
+        """Return the conditional MoG at location x
+
+        Parameters
+        ----------
+        stats : np.array
+            single input location
+        deterministic : bool
+            if True, mean weights are used for Bayesian network
+        """
+        assert stats.shape[0] == 1, 'x.shape[0] needs to be 1'
+
+        a = np.ones(1)
+        ms = [ self.get_mean(stats) ]
+        Us = [ get_cov(self, stats) ]
+
+        return dd.MoG(a=a, ms=ms, Us=Us, seed=self.gen_newseed())
+
+    def get_mean(self, stats):
+        return stats.dot(self.params_dict['means.mW0']) + np.atleast_2d(self.params_dict['means.mb0'])
+
+    def get_cov(self, stats):
+        if self.diag_cov:
+            U = self.params_dict['precisions.mb0']
+            return np.diag(np.exp(np.diag(U.reshape(self.n_outputs, self.n_outputs))))
+        else:
+            raise NotImplementedError
+
+    def gen_newseed(self):
+        """Generates a new random seed"""
+        if self.seed is None:
+            return None
+        else:
+            return self.rng.randint(0, 2**31)
+
+    @property
+    def params_dict(self):
+        """Getter for params as dict"""
+        pdict = {}
+        for p in self.params_dict_:
+            pdict[str(p)] = self.params_dict_[str(p)].copy()
+        return pdict
+
+    @params_dict.setter
+    def params_dict(self, pdict):
+        """Setter for params as dict"""
+        for p in self.params_dict_:
+            if str(p) in pdict.keys():
+                self.params_dict_[str(p)] = pdict[str(p)].copy()
+
+    @property
+    def spec_dict(self):
+        """Specs as dict"""
+        return {'n_inputs': self.n_inputs,
+                'n_outputs': self.n_outputs,
+                'n_components': self.n_components,
+                'seed': self.seed,
+                'svi': self.svi}
+
+    def get_loss(self):
+        return np.nan

--- a/delfi/neuralnet/NeuralNet.py
+++ b/delfi/neuralnet/NeuralNet.py
@@ -19,7 +19,8 @@ def MyLogSumExp(x, axis=None):
 class NeuralNet(object):
     def __init__(self, n_inputs, n_outputs, n_components=1, n_filters=[],
                  n_hiddens=[10, 10], n_rnn=None, impute_missing=True, seed=None,
-                 svi=True):
+                 svi=True, rank=None, homoscedastic=False, 
+                 filter_sizes=[5,3,3], pool_sizes=[2,2,2], n_inputs_hidden=None):
         """Initialize a mixture density network with custom layers
 
         Parameters
@@ -46,10 +47,14 @@ class NeuralNet(object):
         """
         self.impute_missing = impute_missing
         self.n_components = n_components
+        self.rank = rank
+        self.homoscedastic = homoscedastic
         self.n_filters = n_filters
         self.n_hiddens = n_hiddens
         self.n_outputs = n_outputs
         self.svi = svi
+
+        self.n_inputs_hidden = 0 if n_inputs_hidden is None else n_inputs_hidden
 
         self.iws = tt.vector('iws', dtype=dtype)
         if n_rnn is None:
@@ -124,15 +129,17 @@ class NeuralNet(object):
             if rs is not None:
                 self.layer['conv_reshape'] = ll.ReshapeLayer(last(self.layer), rs)
 
+            assert len(filter_sizes) >= len(n_filters)
+
             # add layers
             for l in range(len(n_filters)):
                 self.layer['conv_' + str(l + 1)] = ll.Conv2DLayer(
                     name='c' + str(l + 1),
                     incoming=last(self.layer),
                     num_filters=n_filters[l],
-                    filter_size=3,
-                    stride=(2, 2),
-                    pad=0,
+                    filter_size=filter_sizes[l],
+                    stride=(1,1),
+                    pad=(filter_sizes[l]-1)//2 if pool_sizes[l]==1 else 0,
                     untie_biases=False,
                     W=lasagne.init.GlorotUniform(),
                     b=lasagne.init.Constant(0.),
@@ -140,15 +147,33 @@ class NeuralNet(object):
                     flip_filters=True,
                     convolution=tt.nnet.conv2d)
 
+                if pool_sizes[l] > 1:
+                    self.layer['pool_' + str(l + 1)] = ll.MaxPool2DLayer(
+                        name='p' + str(l+1),
+                        incoming=last(self.layer),
+                        pool_size=pool_sizes[l], 
+                        stride=None, 
+                        ignore_border=True)
+
         # flatten
         self.layer['flatten'] = ll.FlattenLayer(
             incoming=last(self.layer),
             outdim=2)
 
+        if not n_inputs_hidden is None and n_inputs_hidden > 0:
+            self.extra_stats = tt.matrix('extra_stats', dtype=dtype)
+            extra_in = ll.InputLayer((None, n_inputs_hidden), 
+                                     input_var=self.extra_stats)
+            self.layer['extra_input'] = lasagne.layers.ConcatLayer([extra_in, last(self.layer)], 
+                                                   axis=1)
+
+        else:
+            pass
+
         # hidden layers
         for l in range(len(n_hiddens)):
             self.layer['hidden_' + str(l + 1)] = dl.FullyConnectedLayer(
-                last(self.layer), n_units=n_hiddens[l],
+                last(self.layer), n_units=n_hiddens[l], actfun=lnl.rectify,
                 svi=svi, name='h' + str(l + 1))
 
         last_hidden = last(self.layer)
@@ -160,9 +185,15 @@ class NeuralNet(object):
         self.layer['mixture_means'] = dl.MixtureMeansLayer(
             last_hidden, n_components=n_components, n_dim=n_outputs, svi=svi,
             name='means')
-        self.layer['mixture_precisions'] = dl.MixturePrecisionsLayer(
-            last_hidden, n_components=n_components, n_dim=n_outputs, svi=svi,
-            name='precisions')
+
+        if homoscedastic:            
+            self.layer['mixture_precisions'] = dl.MixtureHomoscedasticPrecisionsLayer(
+                last_hidden, n_components=n_components, n_dim=n_outputs, svi=svi,
+                name='precisions', rank=rank, homoscedastic=homoscedastic)
+        else: 
+            self.layer['mixture_precisions'] = dl.MixturePrecisionsLayer(
+                last_hidden, n_components=n_components, n_dim=n_outputs, svi=svi,
+                name='precisions', rank=rank, homoscedastic=homoscedastic)
         last_mog = [self.layer['mixture_weights'],
                     self.layer['mixture_means'],
                     self.layer['mixture_precisions']]
@@ -231,17 +262,23 @@ class NeuralNet(object):
 
     def compile_funs(self):
         """Compiles theano functions"""
+
+        if self.n_inputs_hidden > 0: 
+            stats = [self.stats, self.extra_stats]
+        else:
+            stats = [self.stats]
+
         self._f_eval_comps = theano.function(
-            inputs=[self.stats],
+            inputs=stats,
             outputs=self.comps)
         self._f_eval_lprobs = theano.function(
-            inputs=[self.params, self.stats],
+            inputs=[self.params, *stats],
             outputs=self.lprobs)
         self._f_eval_dcomps = theano.function(
-            inputs=[self.stats],
+            inputs=stats,
             outputs=self.dcomps)
         self._f_eval_dlprobs = theano.function(
-            inputs=[self.params, self.stats],
+            inputs=[self.params, *stats],
             outputs=self.dlprobs)
 
     def eval_comps(self, stats, deterministic=True):
@@ -258,10 +295,17 @@ class NeuralNet(object):
         -------
         mixing coefficients, means and scale matrices
         """
+        n, d = self.n_inputs_hidden, self.n_inputs
+        if self.n_inputs_hidden > 0: 
+            input_stats = [stats[:,:-n].reshape(-1,*d).astype(dtype),
+                           stats[:,-n:].astype(dtype)]
+        else: 
+            input_stats = [stats.reshape(-1,*d).astype(dtype)]
+
         if deterministic:
-            return self._f_eval_dcomps(stats.astype(dtype))
+            return self._f_eval_dcomps(*input_stats)
         else:
-            return self._f_eval_comps(stats.astype(dtype))
+            return self._f_eval_comps(*input_stats)
 
     def eval_lprobs(self, params, stats, deterministic=True):
         """Evaluate log probabilities for given input-output pairs.
@@ -277,10 +321,17 @@ class NeuralNet(object):
         -------
         log probabilities : log p(params|stats)
         """
+        n, d = self.n_inputs_hidden, self.n_inputs
+        if self.n_inputs_hidden > 0: 
+            input_stats = [stats[:,:-n].reshape(-1,*d).astype(dtype),
+                           stats[:,-n:].astype(dtype)]
+        else: 
+            input_stats = [stats.reshape(-1,*d).astype(dtype)]
+
         if deterministic:
-            return self._f_eval_dlprobs(params.astype(dtype), stats.astype(dtype))
+            return self._f_eval_dlprobs(params.astype(dtype), *input_stats)
         else:
-            return self._f_eval_lprobs(params.astype(dtype), stats.astype(dtype))
+            return self._f_eval_lprobs(params.astype(dtype), *input_stats)
 
     def get_mog(self, stats, deterministic=True):
         """Return the conditional MoG at location x

--- a/delfi/neuralnet/Trainer.py
+++ b/delfi/neuralnet/Trainer.py
@@ -128,6 +128,9 @@ class Trainer:
         # initialize variables
         iter = 0
 
+        if n_inputs_hidden == 0 and n_inputs is None:
+            n_inputs = self.network.n_inputs
+
         # minibatch size
         minibatch = self.n_trn_data if minibatch is None else minibatch
         if minibatch > self.n_trn_data:

--- a/delfi/neuralnet/Trainer.py
+++ b/delfi/neuralnet/Trainer.py
@@ -11,7 +11,7 @@ dtype = theano.config.floatX
 class Trainer:
     def __init__(self, network, loss, trn_data, trn_inputs,
                  step=lu.adam, lr=0.001, lr_decay=1.0, max_norm=0.1,
-                 monitor=None, seed=None):
+                 monitor=None, seed=None, **kwargs):
         """Construct and configure the trainer
 
         The trainer takes as inputs a neural network, a loss function and
@@ -60,10 +60,14 @@ class Trainer:
             grads = lu.total_norm_constraint(grads, max_norm=max_norm)
 
         # updates
-        self.lr = lr
+        if 'lr' in kwargs.keys():
+            self.lr = kwargs['lr']
+            kwargs.pop('lr')
+        else:
+            self.lr = lr
         self.lr_decay = lr_decay
         self.lr_op = theano.shared(np.array(self.lr, dtype=dtype))
-        self.updates = step(grads, self.network.aps, learning_rate=self.lr_op)
+        self.updates = step(grads, self.network.aps, learning_rate=self.lr_op, **kwargs)
 
         # check trn_data
         n_trn_data_list = set([x.shape[0] for x in trn_data])
@@ -77,6 +81,8 @@ class Trainer:
             monitor_names, monitor_nodes = zip(*monitor.items())
             self.trn_outputs_names += monitor_names
             self.trn_outputs_nodes += monitor_nodes
+
+        print(self.trn_inputs)
 
         # function for single update
         self.make_update = theano.function(
@@ -94,7 +100,9 @@ class Trainer:
               monitor_every=None,
               stop_on_nan=False,
               tol=None,
-              verbose=False):
+              verbose=False,
+              n_inputs=None,
+              n_inputs_hidden=0):
         """Trains the model
 
         Parameters
@@ -144,6 +152,41 @@ class Trainer:
                 desc += verbose
             pbar.set_description(desc)
 
+
+        if not n_inputs is None and n_inputs_hidden > 0:
+            def split_stats(trn_batch):
+   
+                if len(trn_batch)==3:
+                    th,x,iws = trn_batch
+                    trn_batch = (th, 
+                                 x[:,:-n_inputs_hidden].reshape(-1,*n_inputs),
+                                 x[:,-n_inputs_hidden:],
+                                 iws)
+
+                elif len(trn_batch)==2:
+                    th,x = trn_batch
+                    trn_batch = (th, 
+                                 x[:,:-n_inputs_hidden].reshape(-1,*n_inputs), 
+                                 x[:,-n_inputs_hidden:])
+
+                return trn_batch
+        else:
+            def split_stats(trn_batch):
+
+                if len(trn_batch)==3:
+                    th,x,iws = trn_batch
+                    trn_batch = (th, 
+                                 x.reshape(-1,*n_inputs),
+                                 iws)
+
+                elif len(trn_batch)==2:
+                    th,x = trn_batch
+                    trn_batch = (th, 
+                                 x.reshape(-1,*n_inputs))
+
+                return trn_batch
+
+
         with pbar:
             # loop over epochs
             for epoch in range(epochs):
@@ -155,6 +198,9 @@ class Trainer:
                 for trn_batch in iterate_minibatches(self.trn_data, minibatch,
                                                      seed=self.gen_newseed()):
                     trn_batch = tuple(trn_batch)
+
+                    # split stats into (stats, extra_stats) if needed
+                    trn_batch = split_stats(trn_batch)
 
                     outputs = self.make_update(*trn_batch)
 

--- a/delfi/neuralnet/Trainer_batch.py
+++ b/delfi/neuralnet/Trainer_batch.py
@@ -1,0 +1,264 @@
+import lasagne.updates as lu
+import numpy as np
+import theano
+import theano.tensor as tt
+
+from delfi.utils.progress import no_tqdm, progressbar
+
+dtype = theano.config.floatX
+
+
+class Trainer_rebatch:
+    def __init__(self, network, loss, trn_data, trn_inputs,
+                 step=lu.adam, lr=0.001, lr_decay=1.0, max_norm=0.1,
+                 monitor=None, seed=None):
+        """Construct and configure the trainer
+
+        The trainer takes as inputs a neural network, a loss function and
+        training data. During init the theano functions for training are
+        compiled.
+
+        Parameters
+        ----------
+        network : NeuralNet instance
+            The neural network to train
+        loss : theano variable
+            Loss function to be computed for network training
+        trn_data : tuple of arrays
+            Training data in the form (params, stats)
+        trn_inputs : list of theano variables
+            Theano variables that should contain the the training data
+        step : function
+            Function to call for updates, will pass gradients and parameters
+        lr : float
+            initial learning rate
+        lr_decay : float
+            learning rate decay factor, learning rate for each epoch is
+            set to lr * (lr_decay**epoch)
+        max_norm : float
+            Total norm constraint for gradients
+        monitor : dict
+            Dict containing theano variables (and names as keys) that should be
+            recorded during training along with the loss function
+        seed : int or None
+            If provided, random number generator for batches will be seeded
+        """
+        self.network = network
+        self.loss = loss
+        self.trn_data = trn_data
+        self.trn_inputs = trn_inputs
+
+        self.seed = seed
+        if seed is not None:
+            self.rng = np.random.RandomState(seed=seed)
+        else:
+            self.rng = np.random.RandomState()
+
+        # gradients
+        grads = tt.grad(self.loss, self.network.aps)
+        if max_norm is not None:
+            grads = lu.total_norm_constraint(grads, max_norm=max_norm)
+
+        # updates
+        self.lr = lr
+        self.lr_decay = lr_decay
+        self.lr_op = theano.shared(np.array(self.lr, dtype=dtype))
+        self.updates = step(grads, self.network.aps, learning_rate=self.lr_op)
+
+        # check trn_data
+        n_trn_data_list = set([x.shape[0] for x in trn_data])
+        assert len(n_trn_data_list) == 1, 'trn_data elements got different len'
+        self.n_trn_data = trn_data[0].shape[0]
+
+        # outputs
+        self.trn_outputs_names = ['loss']
+        self.trn_outputs_nodes = [self.loss]
+        if monitor is not None and len(monitor) > 0:
+            monitor_names, monitor_nodes = zip(*monitor.items())
+            self.trn_outputs_names += monitor_names
+            self.trn_outputs_nodes += monitor_nodes
+
+        # function for single update
+        self.make_update = theano.function(
+            inputs=self.trn_inputs,
+            outputs=self.trn_outputs_nodes,
+            updates=self.updates
+        )
+
+        # initialize variables
+        self.loss = float('inf')
+
+    def train(self,
+              epochs=250,
+              minibatch=50,
+              monitor_every=None,
+              stop_on_nan=False,
+              tol=None,
+              verbose=False):
+        """Trains the model
+
+        Parameters
+        ----------
+        epochs : int
+            number of epochs (iterations per sample)
+        minibatch : int
+            minibatch size
+        monitor_every : int
+            monitoring frequency
+        stop_on_nan : bool (default: False)
+            if True, will stop if loss becomes NaN
+        tol : float
+            tolerance criterion for stopping based on training set
+        verbose : bool
+            if True, print progress during training
+
+        Returns
+        -------
+        dict : containing loss values and possibly additional keys
+        """
+
+        # initialize variables
+        iter = 0
+
+        # minibatch size
+        minibatch = self.n_trn_data if minibatch is None else minibatch
+        if minibatch > self.n_trn_data:
+            minibatch = self.n_trn_data
+
+        maxiter = int(self.n_trn_data / minibatch + 0.5) * epochs 
+            
+        # placeholders for outputs
+        trn_outputs = {}
+        for key in self.trn_outputs_names:
+            trn_outputs[key] = []
+
+        # cast trn_data
+        self.trn_data = [x.astype(dtype) for x in self.trn_data]
+
+        if not verbose:
+            pbar = no_tqdm()
+        else:
+            pbar = progressbar(total=maxiter * minibatch)
+            desc = 'Training '
+            if type(verbose) == str:
+                desc += verbose
+            pbar.set_description(desc)
+
+        with pbar:
+            # loop over epochs
+            for epoch in range(epochs):
+                # set learning rate
+                lr_epoch = self.lr * (self.lr_decay**epoch)
+                self.lr_op.set_value(lr_epoch)
+
+                # loop over batches
+                for trn_batch in iterate_minibatches(self.network, self.trn_data, minibatch,
+                                                     seed=self.gen_newseed()):
+                    trn_batch = tuple(trn_batch)
+
+                    outputs = self.make_update(*trn_batch)
+
+                    for name, value in zip(self.trn_outputs_names, outputs):
+                        trn_outputs[name].append(value)
+
+                    trn_loss = trn_outputs['loss'][-1]
+                    diff = self.loss - trn_loss
+                    self.loss = trn_loss
+
+                    # check for convergence
+                    if tol is not None:
+                        if abs(diff) < tol:
+                            break
+
+                    # check for nan
+                    if stop_on_nan and np.isnan(trn_loss):
+                        break
+
+                    pbar.update(minibatch)
+
+        # convert lists to arrays
+        for name, value in trn_outputs.items():
+            trn_outputs[name] = np.asarray(value)
+
+        return trn_outputs
+
+    def gen_newseed(self):
+        """Generates a new random seed"""
+        if self.seed is None:
+            return None
+        else:
+            return self.rng.randint(0, 2**31)
+
+
+def iterate_minibatches(network, trn_data, minibatch=10, seed=None):
+    """Minibatch iterator
+
+    Parameters
+    ----------
+    trn_data : tuple of arrays
+        Training daa
+    minibatch : int
+        Size of batches
+    seed : None or int
+        Seed for minibatch order
+
+    Returns
+    -------
+    trn_batch : tuple of arrays
+        Batch of training data
+    """
+    n_samples = len(trn_data[0])
+    indices = np.arange(n_samples)
+
+    rng = np.random.RandomState(seed=seed)
+    rng.shuffle(indices)
+
+    weight_Z = np.sum(trn_data[2])
+
+    start_idx = 0
+
+    queue = None
+    batches = []
+    while start_idx < n_samples:
+        total_weight = 0
+        end_idx = start_idx
+
+        excerpt = [[], [], []]
+
+        while True:
+            if queue == None:
+                if end_idx >= n_samples:
+                    break
+
+                queue = [ td[indices[end_idx]] for td in trn_data ] 
+                queue[2] = queue[2] * n_samples / weight_Z
+                end_idx += 1
+
+            if queue[2] == 0:
+                queue = None
+                continue
+
+            if total_weight + queue[2] <= minibatch:
+                total_weight += queue[2]
+
+                for i in range(3):
+                    excerpt[i].append(np.asarray(queue[i]))
+                queue = None
+            else:
+                new_excerpt = [ q for q in queue ]
+                new_excerpt[2] = minibatch - total_weight
+
+                if new_excerpt[2] != 0:
+                    for i in range(3):
+                        excerpt[i].append(np.asarray(new_excerpt[i]))
+
+                queue[2] -= minibatch - total_weight
+                total_weight = minibatch
+                break
+            
+        batches.append(excerpt)
+        start_idx = end_idx
+
+    rng.shuffle(batches)
+
+    return batches

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -15,8 +15,12 @@ def test_gauss_shape():
         g = dg.Default(model=m, prior=p, summary=s)
 
         n_samples = 100
-        params, stats = g.gen(n_samples)
+
+        params, stats, sources = g.gen(n_samples)
 
         n_summary = n_params
         assert params.shape == (n_samples, n_params)
         assert stats.shape == (n_samples, n_summary)
+        assert sources.size == n_samples
+        assert np.all(np.in1d(np.unique(sources), [0,1]))
+

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -33,7 +33,7 @@ def test_snpe_inference(n_params=2, seed=42):
     g = dg.Default(model=m, prior=p, summary=s)
 
     # observation
-    _, obs = g.gen(1)
+    _, obs, _ = g.gen(1)
 
     # set up inference
     res = infer.SNPE(g, obs=obs)

--- a/tests/functional/test_trainer.py
+++ b/tests/functional/test_trainer.py
@@ -33,8 +33,8 @@ def test_trainer_updates():
     loss = -tt.mean(nn.lprobs)
 
     trn_inputs = [nn.params, nn.stats]
-    trn_data = g.gen(100)  # params, stats
-    trn_data = tuple(x.astype(dtype) for x in trn_data)
+    th, x, _ = g.gen(100)  # params, stats
+    trn_data = tuple(x.astype(dtype) for x in (th, x))
 
     t = Trainer(network=nn, loss=loss, trn_data=trn_data, trn_inputs=trn_inputs)
 


### PR DESCRIPTION
- support for input with convoluational structure (such as images), and mixed input (conv. *and* non-conv.)
- improved handling of calibration kernels under defensive importance sampling (calibrates only on samples from proposal, ignores samples from prior).
- major rewrite of CDELFI/SNPE-A: stability of analytical correction, option to separate 'Alg. 1' and 'Alg. 2' as described in Papamakarios & Murray
- linear recognition networks and class for handling them in an iterative likelihood-free inference algorithm.