### PR TITLE
Remove PyPI install instructions from docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,12 +5,6 @@ delfi is a Python package for density estimation likelihood-free inference.
 
 .. warning:: The code in this repository is still experimental, and APIs are subject to change without warning.
 
-You can install delfi from PyPI using:
-
-.. code-block:: console
-
-    pip install delfi --user --process-dependency-links
-
 For more details on the installation, see :doc:`installation`.
 
 :doc:`notebooks/quickstart` describes basic usage of delfi.


### PR DESCRIPTION
This PR removes the PyPI install instructions from the homepage of the docs. 

Two of delfi's dependencies are not hosted on PyPI: the 0.2 version of lasagne and Marcel's SNL Python 3 port. PyPI does not permit installing external packages (this used to be possible through `dependency_links` but this option has become deprecated in the latest version of pip). Once delfi does not depend on these packages anymore, we can go back to using PyPI for package hosting.
