### PR TITLE
added remotegenerator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
   - pip install -r requirements.txt
   - python setup.py install
 script:
+  - python -c "import os; os.chdir('tests/functional'); from test_generator import *; test_remotegen()"
   - PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=delfi;
   - travis-sphinx build -n -s docs/
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,6 @@ install:
   - pip install -r requirements.txt
   - python setup.py install
 script:
-  - cp ~/.ssh/known_hosts ~/.ssh/known_hosts_backup
-  - ls ~/.ssh
-  - ls -l ~/.ssh
-  - ls -ld ~/.ssh
   - eval $(ssh-agent -s)
   - PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=delfi;
   - travis-sphinx build -n -s docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,11 @@ install:
   - pip install -r requirements.txt
   - python setup.py install
 script:
-  - python -c "import os; os.chdir('tests/functional'); from test_generator import *; test_remotegen()"
+  - cp ~/.ssh/known_hosts ~/.ssh/known_hosts_backup
+  - ls ~/.ssh
+  - ls -l ~/.ssh
+  - ls -ld ~/.ssh
+  - eval $(ssh-agent -s)
   - PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=delfi;
   - travis-sphinx build -n -s docs/
 after_success:

--- a/delfi/generator/BaseGenerator.py
+++ b/delfi/generator/BaseGenerator.py
@@ -29,7 +29,7 @@ class BaseGenerator(metaclass=ABCMetaDoc):
         self.prior = prior
         self.summary = summary
         self.proposal = None
-
+        self.seed = seed
         self.rng = np.random.RandomState(seed=seed)
 
     def gen_newseed(self):
@@ -51,7 +51,8 @@ class BaseGenerator(metaclass=ABCMetaDoc):
         self.rng.seed(seed=seed)
         self.seed = seed
         self.prior.reseed(self.gen_newseed())
-        self.model.reseed(self.gen_newseed())
+        if self.model is not None:
+            self.model.reseed(self.gen_newseed())
         if self.proposal is not None:
             self.proposal.reseed(self.gen_newseed())
 

--- a/delfi/generator/Default.py
+++ b/delfi/generator/Default.py
@@ -24,7 +24,7 @@ class Default(BaseGenerator):
                         return 'resample'
 
                 elif isinstance(p, dd.Gamma):
-                    if np.any(param[:,ii] < p.offset):
+                    if np.any(param[:, ii] < p.offset):
                         return 'resample'
 
         return 'accept'

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -374,6 +374,7 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
     if from_slurm:  # this function is running on a slurm node
 
         tid = get_slurm_task_index()
+        print('started task {0}\n'.format(tid))
         generator_seed = data['generator_seed'] + tid
         ntasks = int(os.getenv('SLURM_NTASKS'))
 
@@ -421,6 +422,8 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
         for tid in range(ntasks):
             sf, se = os.path.splitext(data['samplefile'])
             samplefile_this_task = sf + '_{0}'.format(tid) + se
+            if not os.path.exists(samplefile_this_task):
+                continue
             os.remove(samplefile_this_task)
 
         outputfile = slurm_options['output'].replace('%j', str(jobid))
@@ -446,6 +449,8 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
     rng = np.random.RandomState(seed=generator_seed + 2500)
     summary_seed = rng.randint(0, 2 ** 31)
     summary = data['summary_class'](*data['summary_args'], seed=summary_seed, **data['summary_kwargs'])
+    prior = data['prior']
+    prior.reseed(rng.randint(0, 2 ** 31))
 
     if n_workers > 1:
         simulator_seeds = [rng.randint(0, 2 ** 31) for _ in range(n_workers)]

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -360,7 +360,7 @@ def get_slurm_task_index():  # pragma: no cover
     return int(os.getenv('SLURM_GTIDS').split(',')[localid])
 
 
-def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no cover
+def mpgen_from_file(filename, n_workers=None, from_slurm=False, cleanup=True):  # pragma: no cover
     """
     Run simulations from a file using a multi-process generator, and save them in a file.
 
@@ -427,6 +427,9 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
         with open(data['samplefile'], 'wb') as f:
             pickle.dump(dict(params=params, stats=stats, time=elapsed_time, task_time=task_time), f,
                         protocol=pickle.HIGHEST_PROTOCOL)
+
+        if not cleanup:
+            return
 
         #clean up all created files except the final samplefile:
         for tid in range(ntasks):

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -376,7 +376,8 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
     if from_slurm:  # this function is running on a slurm node
 
         tid = get_slurm_task_index()
-        print('started task {0}\n'.format(tid))
+        ncpus = os.getenv('SLURM_JOB_CPUS_PER_NODE')
+        print('started task {0}, {1} cpus\n'.format(tid, ncpus))
         generator_seed = data['generator_seed'] + tid
         ntasks = int(os.getenv('SLURM_NTASKS'))
 

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -328,13 +328,12 @@ def mpgen_from_file(filename, use_slurm=None, n_workers=None):
         os.system('sbatch {0}'.format(filename))
 
     if n_workers is None:
-        if data['n_workers'] is None:
-            n_workers = data['n_workers']
-        else:
-            n_workers = mp.cpu_count()
+        n_workers = data['n_workers']
+    if n_workers is None:
+        n_workers = mp.cpu_count()
 
     rng = np.random.RandomState(seed=generator_seed + 25)
-    simulator_seeds = [rng.randint(0, 2**31) for i in range(n_workers)]
+    simulator_seeds = [rng.randint(0, 2**31) for _ in range(n_workers)]
 
     n_workers = np.minimum(n_workers, n_samples)
     simulator_seeds = simulator_seeds[:n_workers]

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -305,9 +305,7 @@ def default_slurm_options():  # pragma: no cover
             'D': os.path.expanduser('~'),
             'ntasks-per-node': 1,
             'nodes': 1,
-            'output': os.path.join(os.path.expanduser('~'), '%j.out'),
-            'get-user-env ': None,
-            'export': 'NONE'
+            'output': os.path.join(os.path.expanduser('~'), '%j.out')  # ,'get-user-env ': None, 'export': 'NONE'
             }
     return opts
 
@@ -367,6 +365,7 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False, cleanup=True):  
     This function can be used as a stand-alone utility, but is mainly meant to be called on a remote host over ssh by a
     RemoteGenerator.
 
+    :param cleanup:
     :param from_slurm:
     :param n_workers:
     :param filename: file describing simulations to be run

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -296,7 +296,7 @@ class MPGenerator(Default):
         self.stop_workers()
 
 
-def default_slurm_opts():
+def default_slurm_options():
     opts = {'clusters': None,
             'time': '1:00:00',
             'chdir': os.path.expanduser('~'),
@@ -311,16 +311,16 @@ def generate_slurm_script(filename):
     with open(filename, 'rb') as f:
         data = pickle.load(f)
 
-    slurm_opts = default_slurm_opts()
-    if data['slurm_opts'] is not None:
-        slurm_opts.update(data['slurm_opts'])
-    assert slurm_opts['clusters'] is not None, "cluster(s) must be specified"
+    slurm_options = default_slurm_options()
+    if data['slurm_options'] is not None:
+        slurm_options.update(data['slurm_options'])
+    assert slurm_options['clusters'] is not None, "cluster(s) must be specified"
 
     slurm_script_file = os.path.splitext(filename)[0] + '_slurm.sh'
     with open(slurm_script_file, 'w') as f:
 
-        assert 'wait' not in slurm_opts.keys() and 'W' not in slurm_opts.keys(), "--wait is on by default, not optional"
-        for key, val in slurm_opts.items():
+        assert 'wait' not in slurm_options.keys() and 'W' not in slurm_options.keys(), "--wait is on by default, not optional"
+        for key, val in slurm_options.items():
             if len(key) == 1:
                 prefix = '-'
                 postfix = ' '
@@ -339,7 +339,7 @@ def generate_slurm_script(filename):
             'mpgen_from_file(\'{0}\', from_slurm=True)'.format(filename)
         f.write('srun {0} -c "{1}"'.format(data['python_executable'], python_commands))
 
-    return slurm_opts, slurm_script_file
+    return slurm_options, slurm_script_file
 
 
 def get_slurm_task_index():
@@ -382,8 +382,8 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):
 
     elif data['use_slurm']:  # start a slurm job that will call this function once per task
 
-        slurm_opts, slurm_script_file = generate_slurm_script(filename)
-        ntasks = int(slurm_opts['ntasks-per-node']) * int(slurm_opts['nodes'])
+        slurm_options, slurm_script_file = generate_slurm_script(filename)
+        ntasks = int(slurm_options['ntasks-per-node']) * int(slurm_options['nodes'])
         os.system('sbatch {0}'.format(slurm_script_file))
         # sbatch will now block until job is completed due to --wait flag
 

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -304,7 +304,7 @@ def default_slurm_options():  # pragma: no cover
             'D': os.path.expanduser('~'),
             'ntasks-per-node': 1,
             'nodes': 1,
-            'output': os.path.join(os.path.expanduser('~'), '%j-%t.out')
+            'output': os.path.join(os.path.expanduser('~'), '%j.out')
             }
     return opts
 
@@ -424,18 +424,10 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
             os.remove(samplefile_this_task)
 
         outputfile = slurm_options['output'].replace('%j', str(jobid))
-        if '%t' in outputfile:
-            outputfiles = [outputfile.replace('%t', str(tid)) for tid in range(ntasks)]
+        if '%' in outputfile:
+            sys.stderr.write('output file(s) not be removed, only %t is supported')
         else:
-            outputfiles = [outputfile]
-        warned = False
-        for f in outputfiles:
-            if '%' in f:
-                if not warned:
-                    sys.stderr.write('cannot clean up output file(s), only %t and %j supported in filename')
-                    warned = True
-                continue
-            os.remove(f)
+            os.remove(outputfile)
 
         return
 

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -305,9 +305,7 @@ def default_slurm_options():  # pragma: no cover
             'D': os.path.expanduser('~'),
             'ntasks-per-node': 1,
             'nodes': 1,
-            'output': os.path.join(os.path.expanduser('~'), '%j.out'),
-            'get-user-env ': None,
-            'export': 'NONE'
+            'output': os.path.join(os.path.expanduser('~'), '%j.out')
             }
     return opts
 

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -346,7 +346,7 @@ def generate_slurm_script(filename):  # pragma: no cover
             f.write(s + '\n')
 
         f.write('#SBATCH --wait\n')  # block execution until the job finishes
-        f.write('source /etc/profile.d/modules.sh\n')  # for LRZ, may not be universal
+        # f.write('source /etc/profile.d/modules.sh\n')  # for LRZ, may not be universal
 
         python_commands = 'from delfi.generator.MPGenerator import mpgen_from_file;'\
             'mpgen_from_file(\'{0}\', from_slurm=True)'.format(filename)

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -309,12 +309,12 @@ def default_slurm_options():  # pragma: no cover
 
 
 def generate_slurm_script(filename):  # pragma: no cover
-    '''
+    """
     Save a slurm script to run mpgen_from_file through a SLURM job manager
 
     :param filename:
     :return:
-    '''
+    """
     with open(filename, 'rb') as f:
         data = pickle.load(f)
 

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -443,14 +443,17 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
         n_workers = mp.cpu_count()
 
     rng = np.random.RandomState(seed=generator_seed + 25)
-    simulator_seeds = [rng.randint(0, 2**31) for _ in range(n_workers)]
 
     n_workers = np.minimum(n_workers, n_samples)
+    simulator_seeds = [rng.randint(0, 2 ** 31) for _ in range(n_workers)]
     simulator_seeds = simulator_seeds[:n_workers]
-
-    models = [data['simulator_class'](seed=s, *data['simulator_args'], **data['simulator_kwargs'])
+    models = [data['simulator_class'](*data['simulator_args'], seed=s, **data['simulator_kwargs'])
               for s in simulator_seeds]
-    g = MPGenerator(models, data['prior'], data['summary'], seed=rng.randint(0, 2**31), verbose=False)
+
+    summary_seed = rng.randint(0, 2 ** 31)
+    summary = data['summary'](*data['summary_args'], seed=summary_seed, **data['summary_kwargs'])
+
+    g = MPGenerator(models, data['prior'], summary, seed=rng.randint(0, 2**31), verbose=False)
     g.proposal = data['proposal']
 
     samples_remaining, params, stats = n_samples, None, None

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -451,7 +451,7 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
               for s in simulator_seeds]
 
     summary_seed = rng.randint(0, 2 ** 31)
-    summary = data['summary'](*data['summary_args'], seed=summary_seed, **data['summary_kwargs'])
+    summary = data['summary_class'](*data['summary_args'], seed=summary_seed, **data['summary_kwargs'])
 
     g = MPGenerator(models, data['prior'], summary, seed=rng.randint(0, 2**31), verbose=False)
     g.proposal = data['proposal']

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -417,7 +417,7 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
         with open(data['samplefile'], 'wb') as f:
             pickle.dump(dict(params=params, stats=stats), f, protocol=pickle.HIGHEST_PROTOCOL)
 
-        # remove task-specific sample files
+        #clean up all created files except the final samplefile:
         for tid in range(ntasks):
             sf, se = os.path.splitext(data['samplefile'])
             samplefile_this_task = sf + '_{0}'.format(tid) + se
@@ -428,6 +428,8 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
             sys.stderr.write('output file(s) not be removed, only %t is supported')
         else:
             os.remove(outputfile)
+
+        os.remove(slurm_script_file)
 
         return
 

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -351,7 +351,7 @@ def generate_slurm_script(filename):  # pragma: no cover
     return slurm_options, slurm_script_file
 
 
-def get_slurm_task_index():
+def get_slurm_task_index():  # pragma: no cover
     localid = int(os.getenv('SLURM_LOCALID'))
     return int(os.getenv('SLURM_GTIDS').split(',')[localid])
 
@@ -391,7 +391,7 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
         result = subprocess.run(['sbatch', slurm_script_file], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         # sbatch will now block until job is completed due to --wait flag
         with open('test.txt', 'w') as f:
-            f.write(result.stdout().decode())
+            f.write(result.stdout.decode())
         if result.returncode != 0:  # e.g. job timed out
             sys.stderr.write('SLURM job terminated abnormally: {0}'.format(result.stderr.decode()))
 

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -347,7 +347,7 @@ def generate_slurm_script(filename):  # pragma: no cover
 
         python_commands = 'from delfi.generator.MPGenerator import mpgen_from_file;'\
             'mpgen_from_file(\'{0}\', from_slurm=True)'.format(filename)
-        f.write('srun {0} -c "{1}"\n'.format(data['python_executable'], python_commands))
+        f.write('mpiexec {0} -c "{1}"\n'.format(data['python_executable'], python_commands))
 
     return slurm_options, slurm_script_file
 

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -300,7 +300,7 @@ class MPGenerator(Default):
 def default_slurm_options():
     opts = {'clusters': None,
             'time': '1:00:00',
-            'chdir': os.path.expanduser('~'),
+            'D': os.path.expanduser('~'),
             'ntasks-per-node': 1,
             'nodes': 1,
             'output': os.path.join(os.path.expanduser('~'), '%j-%t.out')
@@ -380,7 +380,7 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):
 
         tid = get_slurm_task_index()
         generator_seed += tid
-        ntasks = os.getenv('SLURM_NTASKS')
+        ntasks = int(os.getenv('SLURM_NTASKS'))
 
         sf, se = os.path.splitext(samplefile)
         samplefile = sf + '_{0}'.format(tid) + se

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -305,7 +305,9 @@ def default_slurm_options():  # pragma: no cover
             'D': os.path.expanduser('~'),
             'ntasks-per-node': 1,
             'nodes': 1,
-            'output': os.path.join(os.path.expanduser('~'), '%j.out')
+            'output': os.path.join(os.path.expanduser('~'), '%j.out'),
+            'get-user-env ': None,
+            'export': 'NONE'
             }
     return opts
 
@@ -343,6 +345,7 @@ def generate_slurm_script(filename):  # pragma: no cover
                 s += '{0}{1}'.format(postfix, val)
             f.write(s + '\n')
 
+        f.write('source /etc/profile.d/modules.sh\n')  # for LRZ, may not be universal
         f.write('#SBATCH --wait\n')  # block execution until the job finishes
 
         python_commands = 'from delfi.generator.MPGenerator import mpgen_from_file;'\

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -305,7 +305,9 @@ def default_slurm_options():  # pragma: no cover
             'D': os.path.expanduser('~'),
             'ntasks-per-node': 1,
             'nodes': 1,
-            'output': os.path.join(os.path.expanduser('~'), '%j.out')  # ,'get-user-env ': None, 'export': 'NONE'
+            'output': os.path.join(os.path.expanduser('~'), '%j.out'),
+            'get-user-env ': None,
+            'export': 'NONE'
             }
     return opts
 
@@ -348,7 +350,7 @@ def generate_slurm_script(filename):  # pragma: no cover
 
         python_commands = 'from delfi.generator.MPGenerator import mpgen_from_file;'\
             'mpgen_from_file(\'{0}\', from_slurm=True)'.format(filename)
-        f.write('mpiexec {0} -c "{1}"\n'.format(data['python_executable'], python_commands))
+        f.write('srun {0} -c "{1}"\n'.format(data['python_executable'], python_commands))
 
     return slurm_options, slurm_script_file
 

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -345,8 +345,8 @@ def generate_slurm_script(filename):  # pragma: no cover
                 s += '{0}{1}'.format(postfix, val)
             f.write(s + '\n')
 
-        f.write('source /etc/profile.d/modules.sh\n')  # for LRZ, may not be universal
         f.write('#SBATCH --wait\n')  # block execution until the job finishes
+        f.write('source /etc/profile.d/modules.sh\n')  # for LRZ, may not be universal
 
         python_commands = 'from delfi.generator.MPGenerator import mpgen_from_file;'\
             'mpgen_from_file(\'{0}\', from_slurm=True)'.format(filename)

--- a/delfi/generator/MPGenerator.py
+++ b/delfi/generator/MPGenerator.py
@@ -423,7 +423,7 @@ def mpgen_from_file(filename, n_workers=None, from_slurm=False):  # pragma: no c
             samplefile_this_task = sf + '_{0}'.format(tid) + se
             os.remove(samplefile_this_task)
 
-        outputfile = slurm_options['outputfile'].replace('%j', str(jobid))
+        outputfile = slurm_options['output'].replace('%j', str(jobid))
         if '%t' in outputfile:
             outputfiles = [outputfile.replace('%t', str(tid)) for tid in range(ntasks)]
         else:

--- a/delfi/generator/RemoteGenerator.py
+++ b/delfi/generator/RemoteGenerator.py
@@ -135,7 +135,7 @@ class RemoteGenerator(Default):
                  simulator_args=None, simulator_kwargs=None, summary_args=None, summary_kwargs=None,
                  save_every=None,
                  remote_python_executable=None, use_slurm=False, slurm_options=None,
-                 local_work_path=None, remote_work_path=None, persistent=True,
+                 local_work_path=None, remote_work_path=None, persistent=False,
                  seed=None):
         """
         Generator that creates an MPGenerator on a remote server and uses that

--- a/delfi/generator/RemoteGenerator.py
+++ b/delfi/generator/RemoteGenerator.py
@@ -172,8 +172,8 @@ class RemoteGenerator(Default):
         samples_remaining, params, stats = n_samples, None, None
         while samples_remaining > 0:
             next_params, next_stats = run_remote(self.simulator_class,
-                                                 self.prior,
                                                  self.summary_class,
+                                                 self.prior,
                                                  n_samples,
                                                  hostname=self.hostname,
                                                  username=self.username,

--- a/delfi/generator/RemoteGenerator.py
+++ b/delfi/generator/RemoteGenerator.py
@@ -165,23 +165,23 @@ class RemoteGenerator(Default):
         samples_remaining, params, stats = n_samples, None, None
         while samples_remaining > 0:
             next_params, next_stats = run_remote(self.simulator_class,
-                                                  self.prior,
-                                                  self.summary,
-                                                  n_samples,
-                                                  hostname=self.hostname,
-                                                  username=self.username,
-                                                  simulator_args=self.simulator_args,
-                                                  simulator_kwargs=self.simulator_kwargs,
-                                                  remote_python_executable=self.remote_python_executable,
-                                                  remote_work_path=self.remote_work_path,
-                                                  local_work_path=self.local_work_path,
-                                                  proposal=self.proposal,
-                                                  n_workers=n_workers,
-                                                  generator_seed=self.gen_newseed(),
-                                                  use_slurm=self.use_slurm,
-                                                  save_every=self.save_every,
-                                                  slurm_options=self.slurm_options,
-                                                  **kwargs)
+                                                 self.prior,
+                                                 self.summary,
+                                                 n_samples,
+                                                 hostname=self.hostname,
+                                                 username=self.username,
+                                                 simulator_args=self.simulator_args,
+                                                 simulator_kwargs=self.simulator_kwargs,
+                                                 remote_python_executable=self.remote_python_executable,
+                                                 remote_work_path=self.remote_work_path,
+                                                 local_work_path=self.local_work_path,
+                                                 proposal=self.proposal,
+                                                 n_workers=n_workers,
+                                                 generator_seed=self.gen_newseed(),
+                                                 use_slurm=self.use_slurm,
+                                                 save_every=self.save_every,
+                                                 slurm_options=self.slurm_options,
+                                                 **kwargs)
             if params is None:
                 params, stats = next_params, next_stats
             else:

--- a/delfi/generator/RemoteGenerator.py
+++ b/delfi/generator/RemoteGenerator.py
@@ -18,7 +18,6 @@ def run_remote(simulator_class,
                local_work_path=None,
                proposal=None,  # use prior by default
                n_workers=None,  # use number of remote cpus by default
-               simulator_seeds=None,
                generator_seed=None,
                use_slurm=False,  # use the job manager with sbatch
                slurm_options=None,
@@ -26,6 +25,8 @@ def run_remote(simulator_class,
     """
     Create a MPGenerator on a remote server and generate samples.
 
+    :param remote_python_executable:
+    :param slurm_options:
     :param simulator_class:
     :param prior:
     :param summary:
@@ -34,12 +35,11 @@ def run_remote(simulator_class,
     :param username:
     :param simulator_args:
     :param simulator_kwargs:
-    :param remote_python_path:
+    :param remote_python_executable:
     :param remote_work_path:
     :param local_work_path:
     :param proposal:
     :param n_workers:
-    :param simulator_seeds:
     :param generator_seed:
     :param use_slurm:
     :param generator_kwargs:
@@ -137,7 +137,7 @@ class RemoteGenerator(Default):
                  simulator_class, prior, summary,
                  hostname, username,
                  simulator_args=None, simulator_kwargs=None,
-                 remote_python_executable=None, use_slurm=False,
+                 remote_python_executable=None, use_slurm=False, slurm_options=None,
                  local_work_path=None, remote_work_path=None,
                  seed=None):
         """
@@ -159,10 +159,10 @@ class RemoteGenerator(Default):
         self.simulator_class, self.hostname, self.username,\
             self.simulator_args, self.simulator_kwargs, \
             self.remote_python_executable, self.local_work_path,\
-            self.remote_work_path, self.use_slurm = \
+            self.remote_work_path, self.use_slurm, self.slurm_options = \
             simulator_class, hostname, username, simulator_args,\
             simulator_kwargs, remote_python_executable, local_work_path, \
-            remote_work_path, use_slurm
+            remote_work_path, use_slurm, slurm_options
 
     def gen(self, n_samples, n_workers=None, **kwargs):
         self.prior.reseed(self.gen_newseed())
@@ -184,4 +184,5 @@ class RemoteGenerator(Default):
                        n_workers=n_workers,
                        generator_seed=self.gen_newseed(),
                        use_slurm=self.use_slurm,
+                       slurm_options=self.slurm_options,
                        **kwargs)

--- a/delfi/generator/RemoteGenerator.py
+++ b/delfi/generator/RemoteGenerator.py
@@ -56,6 +56,10 @@ def run_remote(simulator_class,
         simulator_args = []
     if simulator_kwargs is None:
         simulator_kwargs = dict()
+    if summary_args is None:
+        summary_args = []
+    if summary_kwargs is None:
+        summary_kwargs = dict()
     if remote_python_executable is None:
         remote_python_executable = 'python3'
     if remote_work_path is None:

--- a/delfi/generator/RemoteGenerator.py
+++ b/delfi/generator/RemoteGenerator.py
@@ -85,35 +85,24 @@ def run_remote(simulator_class,
         pickle.dump(data, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     # copy the data file to the remote host
-    result = subprocess.run(
-        ['scp', datafile_local,
-         '{0}@{1}:{2}'.format(username, hostname, datafile_remote)],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    assert result.returncode == 0, \
-        "failed to copy data file to remote host: {0}" \
-        .format(result.stderr.decode())
+    result = subprocess.run(['scp', datafile_local, '{0}@{1}:{2}'.format(username, hostname, datafile_remote)],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.returncode == 0, "failed to copy data file to remote host: {0}".format(result.stderr.decode())
 
     # generate samples remotely
     python_commands = 'from delfi.generator.MPGenerator import ' \
         'mpgen_from_file; mpgen_from_file(\'{0}\')'.format(datafile_remote)
 
-    remote_command = '{0} -c \"{1}\"'.format(remote_python_executable,
-                                             python_commands)
+    remote_command = '{0} -c \"{1}\"'.format(remote_python_executable, python_commands)
 
     result = subprocess.run(['ssh', hostname, '-l', username, remote_command],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-    assert result.returncode == 0, \
-        "failed to run code on remote host: {0}".format(result.stderr.decode())
+    assert result.returncode == 0, "failed to run code on remote host: {0}".format(result.stderr.decode())
 
     # copy samples back to local host
-    result = subprocess.run(
-        ['scp', '{0}@{1}:{2}'.format(username, hostname, samplefile_remote),
-         samplefile_local],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    assert result.returncode == 0, \
-        "failed to copy samples file from remote host: {0}" \
-        .format(result.stderr.decode())
+    result = subprocess.run(['scp', '{0}@{1}:{2}'.format(username, hostname, samplefile_remote), samplefile_local],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.returncode == 0, "failed to copy samples file from remote host: {0}".format(result.stderr.decode())
 
     with open(samplefile_local, 'rb') as f:
         samples = pickle.load(f)
@@ -121,13 +110,9 @@ def run_remote(simulator_class,
     # clean up by deleting data/sample files on remote/local machines
     os.remove(datafile_local)
     os.remove(samplefile_local)
-    result = subprocess.run(['ssh', hostname, '-l', username,
-                             'rm {0} && rm {1}'.format(datafile_remote,
-                                                       samplefile_remote)],
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    assert result.returncode == 0, \
-        "failed to delete file(s) from remote host: {0}" \
-        .format(result.stderr.decode())
+    result = subprocess.run(['ssh', hostname, '-l', username, 'rm {0} && rm {1}'.format(datafile_remote,
+                             samplefile_remote)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.returncode == 0, "failed to delete file(s) from remote host: {0}".format(result.stderr.decode())
 
     return samples['params'], samples['stats']
 

--- a/delfi/generator/RemoteGenerator.py
+++ b/delfi/generator/RemoteGenerator.py
@@ -1,0 +1,186 @@
+import os
+import uuid
+import pickle
+import subprocess
+from delfi.generator.Default import Default
+
+
+def run_remote(simulator_class,
+               prior,  # might still be relevant with proposals due to rejection
+               summary,
+               n_samples,
+               hostname,
+               username,
+               simulator_args=None,
+               simulator_kwargs=None,
+               remote_python_path=None,
+               remote_work_path=None,
+               local_work_path=None,
+               proposal=None,  # use prior by default
+               n_workers=None,  # use number of remote cpus by default
+               simulator_seeds=None,
+               generator_seed=None,
+               use_slurm=False,  # use the job manager with sbatch
+               **generator_kwargs):
+    """
+    Create a MPGenerator on a remote server and generate samples.
+
+    :param simulator_class:
+    :param prior:
+    :param summary:
+    :param n_samples:
+    :param hostname:
+    :param username:
+    :param remote_python_path:
+    :param remote_work_path:
+    :param local_work_path:
+    :param proposal:
+    :param n_workers:
+    :param simulator_seeds:
+    :param generator_seed:
+    :param use_slurm:
+    :param generator_kwargs:
+    :return: (params, stats)
+    """
+    if simulator_args is None:
+        simulator_args = []
+    if simulator_kwargs is None:
+        simulator_kwargs = dict()
+    if remote_python_path is None:
+        remote_python_path = 'python3'
+    if remote_work_path is None:
+        remote_work_path = './'
+    if local_work_path is None:
+        local_work_path = os.getenv('HOME')
+    if local_work_path is None:
+        local_work_path = os.getcwd()
+
+    U = str(uuid.uuid1())
+    datafile_local = os.path.join(local_work_path,
+                                  'local_data_{0}.pickle'.format(U))
+    datafile_remote = os.path.join(remote_work_path,
+                                   'remote_data_{0}.pickle'.format(U))
+    samplefile_local = os.path.join(local_work_path,
+                                    'local_samples_{0}.pickle'.format(U))
+    samplefile_remote = os.path.join(remote_work_path,
+                                     'remote_samples_{0}.pickle'.format(U))
+
+    data = dict(simulator_class=simulator_class, simulator_args=simulator_args,
+                simulator_kwargs=simulator_kwargs, prior=prior, summary=summary,
+                proposal=proposal, n_samples=n_samples,
+                generator_seed=generator_seed, simulator_seeds=simulator_seeds,
+                n_workers=n_workers, generator_kwargs=generator_kwargs,
+                samplefile=samplefile_remote)
+
+    with open(datafile_local, 'wb') as f:
+        pickle.dump(data, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    # copy the data file to the remote host
+    result = subprocess.run(
+        ['scp', datafile_local,
+         '{0}@{1}:{2}'.format(username, hostname, datafile_remote)],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.returncode == 0, \
+        "failed to copy data file to remote host: {0}" \
+        .format(result.stderr.decode())
+
+    # generate samples remotely
+    python_commands = 'from delfi.generator.MPGenerator import ' \
+        'mpgen_from_file; mpgen_from_file(\'{0}\')'.format(datafile_remote)
+
+    if use_slurm:
+        raise NotImplementedError
+    else:
+        remote_command = '{0} -c \"{1}\"'.format(remote_python_path,
+                                                 python_commands)
+
+    result = subprocess.run(['ssh', hostname, '-l', username, remote_command],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    assert result.returncode == 0, \
+        "failed to run code on remote host: {0}".format(result.stderr.decode())
+
+    # copy samples back to local host
+    result = subprocess.run(
+        ['scp', '{0}@{1}:{2}'.format(username, hostname, samplefile_remote),
+         samplefile_local],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.returncode == 0, \
+        "failed to copy samples file from remote host: {0}" \
+        .format(result.stderr.decode())
+
+    with open(samplefile_local, 'rb') as f:
+        samples = pickle.load(f)
+
+    # clean up by deleting data/sample files on remote/local machines
+    os.remove(datafile_local)
+    os.remove(samplefile_local)
+    result = subprocess.run(['ssh', hostname, '-l', username,
+                             'rm {0} && rm {1}'.format(datafile_remote,
+                                                       samplefile_remote)],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    assert result.returncode == 0, \
+        "failed to delete file(s) from remote host: {0}" \
+        .format(result.stderr.decode())
+
+    return samples['params'], samples['stats']
+
+
+class RemoteGenerator(Default):
+    def __init__(self,
+                 simulator_class, prior, summary,
+                 hostname, username,
+                 simulator_args=None, simulator_kwargs=None,
+                 remote_python_path=None, use_slurm=False,
+                 local_work_path=None, remote_work_path=None,
+                 seed=None):
+        """
+        Generator that creates an MPGenerator on a remote server and uses that
+        to run simulations.
+
+        :param simulator_class:
+        :param prior:
+        :param summary:
+        :param hostname:
+        :param username:
+        :param remote_python_path:
+        :param use_slurm:
+        :param local_work_path:
+        :param remote_work_path:
+        :param seed:
+        """
+        super().__init__(model=None, prior=prior, summary=summary, seed=seed)
+        self.simulator_class, self.hostname, self.username,\
+            self.simulator_args, self.simulator_kwargs, \
+            self.remote_python_path, self.local_work_path,\
+            self.remote_work_path, self.use_slurm = \
+            simulator_class, hostname, username, simulator_args,\
+            simulator_kwargs, remote_python_path, local_work_path, \
+            remote_work_path, use_slurm
+
+    def gen(self, n_samples, n_workers=None, **kwargs):
+        self.prior.reseed(self.gen_newseed())
+        self.summary.reseed(self.gen_newseed())
+
+        if n_workers is not None:
+            simulator_seeds = [self.gen_newseed() for _ in range(n_workers)]
+        else:
+            simulator_seeds = None
+
+        return run_remote(self.simulator_class,
+                          self.prior,
+                          self.summary,
+                          n_samples,
+                          hostname=self.hostname,
+                          username=self.username,
+                          simulator_args=self.simulator_args,
+                          simulator_kwargs=self.simulator_kwargs,
+                          remote_python_path=self.remote_python_path,
+                          remote_work_path=self.remote_work_path,
+                          local_work_path=self.local_work_path,
+                          proposal=self.proposal,
+                          n_workers=n_workers,
+                          simulator_seeds=simulator_seeds,
+                          generator_seed=self.gen_newseed(),
+                          use_slurm=self.use_slurm,
+                          **kwargs)

--- a/delfi/generator/RemoteGenerator.py
+++ b/delfi/generator/RemoteGenerator.py
@@ -31,6 +31,8 @@ def run_remote(simulator_class,
     :param n_samples:
     :param hostname:
     :param username:
+    :param simulator_args:
+    :param simulator_kwargs:
     :param remote_python_path:
     :param remote_work_path:
     :param local_work_path:
@@ -55,15 +57,17 @@ def run_remote(simulator_class,
     if local_work_path is None:
         local_work_path = os.getcwd()
 
-    U = str(uuid.uuid1())
+    # define file names. important to use different local/remote names in case
+    # we're ssh-ing into localhost etc.
+    uu = str(uuid.uuid1())
     datafile_local = os.path.join(local_work_path,
-                                  'local_data_{0}.pickle'.format(U))
+                                  'local_data_{0}.pickle'.format(uu))
     datafile_remote = os.path.join(remote_work_path,
-                                   'remote_data_{0}.pickle'.format(U))
+                                   'remote_data_{0}.pickle'.format(uu))
     samplefile_local = os.path.join(local_work_path,
-                                    'local_samples_{0}.pickle'.format(U))
+                                    'local_samples_{0}.pickle'.format(uu))
     samplefile_remote = os.path.join(remote_work_path,
-                                     'remote_samples_{0}.pickle'.format(U))
+                                     'remote_samples_{0}.pickle'.format(uu))
 
     data = dict(simulator_class=simulator_class, simulator_args=simulator_args,
                 simulator_kwargs=simulator_kwargs, prior=prior, summary=summary,
@@ -125,6 +129,13 @@ def run_remote(simulator_class,
 
     return samples['params'], samples['stats']
 
+
+def generate_slurm_script(scriptfile=None,
+                          outputfile=None,
+                          ):
+    '--delay-boot=0'
+    '--job-name='
+    '--output=.%j.%N.out'
 
 class RemoteGenerator(Default):
     def __init__(self,

--- a/delfi/generator/__init__.py
+++ b/delfi/generator/__init__.py
@@ -1,3 +1,4 @@
 from delfi.generator.Default import Default
 from delfi.generator.MPGenerator import MPGenerator
 from delfi.generator.RejKernel import RejKernel
+from delfi.generator.RemoteGenerator import RemoteGenerator

--- a/delfi/neuralnet/layers/MixturePrecisions.py
+++ b/delfi/neuralnet/layers/MixturePrecisions.py
@@ -48,6 +48,8 @@ class MixturePrecisionsLayer(lasagne.layers.Layer):
             Function to initialise weights for log std of weight (bias);
             applied per component
         min_precisions: 1D numpy array of float32 or None
+            Minimum values for the diagonal elements of the precision matrix,
+            for all components
         """
         super(MixturePrecisionsLayer, self).__init__(incoming, **kwargs)
         self.n_components = n_components
@@ -132,7 +134,7 @@ class MixturePrecisionsLayer(lasagne.layers.Layer):
         ldetUs = [tt.sum(tt.sum(diag_mask * za, axis=2), axis=1)
                   for za in zas_reshaped]
 
-        # enforce lower bound on diagonal elements of the Precision matices
+        # enforce lower bound on diagonal elements of the precision matrices
         if self.min_U_column_norms is not None:
             U_column_norms = \
                 [tt.sqrt(tt.sum(U**2, axis=1)).reshape((-1, self.n_dim))

--- a/delfi/summarystats/BaseSummaryStats.py
+++ b/delfi/summarystats/BaseSummaryStats.py
@@ -48,3 +48,7 @@ class BaseSummaryStats(metaclass=ABCMetaDoc):
             return None
         else:
             return self.rng.randint(0, 2**31)
+
+    def reseed(self, seed):
+        self.rng.seed(seed=seed)
+        self.seed = seed

--- a/delfi/utils/io.py
+++ b/delfi/utils/io.py
@@ -93,6 +93,7 @@ def run_function_from_file(file, function_name, *args, starting_path=None, **kwa
     :return:
     """
     assert isinstance(function_name, str)
+    assert os.path.exists(file), "file not found: {0}".format(file)
     if starting_path is not None:
         prev_dir = os.getcwd()
         os.chdir(starting_path)

--- a/delfi/utils/io.py
+++ b/delfi/utils/io.py
@@ -1,7 +1,7 @@
-import collections
 import dill as pickle
 import fnmatch
 import os
+from importlib.util import spec_from_file_location, module_from_spec
 
 from delfi.neuralnet.NeuralNet import NeuralNet
 
@@ -76,3 +76,41 @@ def save_pkl(data, file):
     f = open(file, 'wb')
     pickle.dump(data, f)
     f.close()
+
+
+def run_function_from_file(file, function_name, *args, starting_path=None, **kwargs):
+    """
+    Utility to run a retrieve a function by name from a python file and run it with optional inputs.
+
+    This can be useful for running simulators on remote hosts with installing/importing the necessary modules on the
+    client.
+    :param starting_path:
+    :param function_name:
+    :param file:
+    :param function_name:
+    :param args:
+    :param kwargs:
+    :return:
+    """
+    assert isinstance(function_name, str)
+    if starting_path is not None:
+        prev_dir = os.getcwd()
+        os.chdir(starting_path)
+
+    try:
+        spec = spec_from_file_location('rfff_module', file)
+        module = module_from_spec(spec)
+        spec.loader.exec_module(module)
+        f = eval('module.{0}'.format(function_name))
+        success = True
+    except Exception as e:
+        success = False
+        err = e
+
+    if starting_path is not None:
+        os.chdir(prev_dir)
+
+    if not success:
+        raise err
+
+    return f(*args, **kwargs)

--- a/delfi/utils/io.py
+++ b/delfi/utils/io.py
@@ -1,9 +1,7 @@
 import dill as pickle
-import fnmatch
 import os
 from importlib.util import spec_from_file_location, module_from_spec
-
-from delfi.neuralnet.NeuralNet import NeuralNet
+from importlib import import_module
 
 
 def load(file):
@@ -78,9 +76,41 @@ def save_pkl(data, file):
     f.close()
 
 
+def import_from_module_and_run(module_name, function_name, *args, starting_path=None, **kwargs):
+    """
+
+    :param module_name:
+    :param function_name:
+    :param args:
+    :param starting_path:
+    :param kwargs:
+    :return:
+    """
+    assert isinstance(function_name, str) and isinstance(module_name, str)
+    if starting_path is not None:
+        prev_dir = os.getcwd()
+        os.chdir(starting_path)
+
+    try:
+        m = import_module(module_name)
+        f = getattr(m, function_name)
+        result = f(*args, **kwargs)
+        err = None
+    except Exception as e:
+        err = e
+    finally:
+        if starting_path is not None:
+            os.chdir(prev_dir)
+
+    if err is not None:
+        raise err
+
+    return result
+
+
 def run_function_from_file(file, function_name, *args, starting_path=None, **kwargs):
     """
-    Utility to run a retrieve a function by name from a python file and run it with optional inputs.
+    Utility to retrieve a function by name from a python file and run it with optional inputs.
 
     This can be useful for running simulators on remote hosts with installing/importing the necessary modules on the
     client.

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -159,5 +159,6 @@ def dont_test_remotegen_slum(n_samples=1000, n_params=2, seed=66,
                            use_slurm=True,
                            remote_python_executable=remote_python_executable,
                            remote_work_path=remote_work_path,
+                           slurm_options=slurm_options,
                            seed=seed + 2)
     params, stats = g.gen(n_samples, verbose=False)

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -96,14 +96,14 @@ def test_remotegen(n_samples=1000, n_params=2, seed=66):
 
     # run some diagnostics and print results to stderr (so we can see it on CI servers)
     sshdir = os.path.expanduser('~/.ssh/')
-    sys.stdout.write(subprocess.run(['ssh-add', '-l'], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
-    sys.stdout.write(subprocess.run(['ls', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
-    sys.stdout.write(subprocess.run(['cat', os.path.join(sshdir, 'authorized_keys')],
+    sys.stderr.write(subprocess.run(['ssh-add', '-l'], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
+    sys.stderr.write(subprocess.run(['ls', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
+    sys.stderr.write(subprocess.run(['cat', os.path.join(sshdir, 'authorized_keys')],
                                     stdout=subprocess.PIPE).stdout.decode() + '\n\n')
-    sys.stdout.write(subprocess.run(['cat', os.path.join(sshdir, 'known_hosts')],
+    sys.stderr.write(subprocess.run(['cat', os.path.join(sshdir, 'known_hosts')],
                                     stdout=subprocess.PIPE).stdout.decode() + '\n\n')
-    sys.stdout.write(subprocess.run(['ls', '-ld', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
-    sys.stdout.write(subprocess.run(['ls', '-l', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
+    sys.stderr.write(subprocess.run(['ls', '-ld', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
+    sys.stderr.write(subprocess.run(['ls', '-l', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
 
     try:
         g = dg.RemoteGenerator(simulator_class=Gauss,

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -151,7 +151,9 @@ def dont_test_remotegen_slurm(n_samples=500, n_params=2, seed=66, save_every=200
     simulator_kwargs = dict(dim=2)
 
     slurm_options = {'clusters': clusters,
-                     'time': '0:10:00'}
+                     'time': '0:10:00',
+                     'ntasks-per-node': 2,
+                     'nodes': 2}
 
     g = dg.RemoteGenerator(simulator_class=Gauss,
                            prior=p, summary=s,

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -142,6 +142,8 @@ def dont_test_remotegen_slum(n_samples=1000, n_params=2, seed=66,
                              remote_python_executable=None, remote_work_path=None):
     assert type(hostname) is str and type(username) is str, "hostname and username must be provided"
     assert type(clusters) is str, "cluster(s) must be specified as a (comma-delimited) string"
+    '''this test is currently disabled because we don't have slurm running on travis right now. it works fine
+    if it's run locally on a machine with key-based ssh-access to a SLURM cluster, as of 17.09.2019'''
 
     p = dd.Gaussian(m=np.zeros((n_params,)), S=np.eye(n_params), seed=seed)
     s = ds.Identity(seed=seed + 1)
@@ -162,3 +164,4 @@ def dont_test_remotegen_slum(n_samples=1000, n_params=2, seed=66,
                            slurm_options=slurm_options,
                            seed=seed + 2)
     params, stats = g.gen(n_samples, verbose=False)
+    return params, stats

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -115,7 +115,7 @@ def test_remotegen(n_samples=1000, n_params=2, seed=66, run_diagnostics=False):
                                username=username,
                                simulator_kwargs=simulator_kwargs,
                                use_slurm=False,
-                               remote_python_path=sys.executable,
+                               remote_python_executable=sys.executable,
                                seed=seed+2)
         params, stats = g.gen(n_samples, verbose=False)
         success = True

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -135,3 +135,29 @@ def test_remotegen(n_samples=1000, n_params=2, seed=66, run_diagnostics=False):
     # make sure the different models are providing different outputs
     assert np.unique(params.size) == params.size
     assert np.unique(stats.size) == stats.size
+
+
+def dont_test_remotegen_slum(n_samples=1000, n_params=2, seed=66,
+                             hostname=None, username=None, clusters=None,
+                             remote_python_executable=None, remote_work_path=None):
+    assert type(hostname) is str and type(username) is str, "hostname and username must be provided"
+    assert type(clusters) is str, "cluster(s) must be specified as a (comma-delimited) string"
+
+    p = dd.Gaussian(m=np.zeros((n_params,)), S=np.eye(n_params), seed=seed)
+    s = ds.Identity(seed=seed + 1)
+
+    simulator_kwargs = dict(dim=2)
+
+    slurm_options = {'clusters': clusters,
+                     'time': '0:05:00'}
+
+    g = dg.RemoteGenerator(simulator_class=Gauss,
+                           prior=p, summary=s,
+                           hostname=hostname,
+                           username=username,
+                           simulator_kwargs=simulator_kwargs,
+                           use_slurm=True,
+                           remote_python_executable=remote_python_executable,
+                           remote_work_path=remote_work_path,
+                           seed=seed + 2)
+    params, stats = g.gen(n_samples, verbose=False, slurm_options=slurm_options)

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -160,4 +160,4 @@ def dont_test_remotegen_slum(n_samples=1000, n_params=2, seed=66,
                            remote_python_executable=remote_python_executable,
                            remote_work_path=remote_work_path,
                            seed=seed + 2)
-    params, stats = g.gen(n_samples, verbose=False, slurm_options=slurm_options)
+    params, stats = g.gen(n_samples, verbose=False)

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -137,7 +137,7 @@ def test_remotegen(n_samples=1000, n_params=2, seed=66, run_diagnostics=False):
     assert np.unique(stats.size) == stats.size
 
 
-def dont_test_remotegen_slurm(n_samples=1000, n_params=2, seed=66,
+def dont_test_remotegen_slurm(n_samples=1000, n_params=2, seed=66, save_every=100,
                              hostname=None, username=None, clusters=None,
                              remote_python_executable=None, remote_work_path=None):
     assert type(hostname) is str and type(username) is str, "hostname and username must be provided"
@@ -162,6 +162,7 @@ def dont_test_remotegen_slurm(n_samples=1000, n_params=2, seed=66,
                            remote_python_executable=remote_python_executable,
                            remote_work_path=remote_work_path,
                            slurm_options=slurm_options,
+                           save_every=save_every,
                            seed=seed + 2)
     params, stats = g.gen(n_samples, verbose=False)
     return params, stats

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -78,7 +78,6 @@ def test_remotegen(n_samples=1000, n_params=2, seed=66, run_diagnostics=False):
     os.system seems to have no effect.
     """
     p = dd.Gaussian(m=np.zeros((n_params,)), S=np.eye(n_params), seed=seed)
-    s = ds.Identity(seed=seed + 1)
 
     simulator_kwargs = dict(dim=2)
 
@@ -110,7 +109,7 @@ def test_remotegen(n_samples=1000, n_params=2, seed=66, run_diagnostics=False):
 
     try:
         g = dg.RemoteGenerator(simulator_class=Gauss,
-                               prior=p, summary=s,
+                               prior=p, summary_class=ds.Identity,
                                hostname=hostname,
                                username=username,
                                simulator_kwargs=simulator_kwargs,
@@ -146,7 +145,6 @@ def dont_test_remotegen_slurm(n_samples=500, n_params=2, seed=66, save_every=200
     if it's run locally on a machine with key-based ssh-access to a SLURM cluster, as of 17.09.2019'''
 
     p = dd.Gaussian(m=np.zeros((n_params,)), S=np.eye(n_params), seed=seed)
-    s = ds.Identity(seed=seed + 1)
 
     simulator_kwargs = dict(dim=2)
 
@@ -156,7 +154,7 @@ def dont_test_remotegen_slurm(n_samples=500, n_params=2, seed=66, save_every=200
                      'nodes': 2}
 
     g = dg.RemoteGenerator(simulator_class=Gauss,
-                           prior=p, summary=s,
+                           prior=p, summary_class=ds.Identity,
                            hostname=hostname,
                            username=username,
                            simulator_kwargs=simulator_kwargs,

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -137,7 +137,7 @@ def test_remotegen(n_samples=1000, n_params=2, seed=66, run_diagnostics=False):
     assert np.unique(stats.size) == stats.size
 
 
-def dont_test_remotegen_slurm(n_samples=1000, n_params=2, seed=66, save_every=100,
+def dont_test_remotegen_slurm(n_samples=500, n_params=2, seed=66, save_every=200,
                              hostname=None, username=None, clusters=None,
                              remote_python_executable=None, remote_work_path=None):
     assert type(hostname) is str and type(username) is str, "hostname and username must be provided"
@@ -151,7 +151,7 @@ def dont_test_remotegen_slurm(n_samples=1000, n_params=2, seed=66, save_every=10
     simulator_kwargs = dict(dim=2)
 
     slurm_options = {'clusters': clusters,
-                     'time': '0:05:00'}
+                     'time': '0:10:00'}
 
     g = dg.RemoteGenerator(simulator_class=Gauss,
                            prior=p, summary=s,

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -137,7 +137,7 @@ def test_remotegen(n_samples=1000, n_params=2, seed=66, run_diagnostics=False):
     assert np.unique(stats.size) == stats.size
 
 
-def dont_test_remotegen_slum(n_samples=1000, n_params=2, seed=66,
+def dont_test_remotegen_slurm(n_samples=1000, n_params=2, seed=66,
                              hostname=None, username=None, clusters=None,
                              remote_python_executable=None, remote_work_path=None):
     assert type(hostname) is str and type(username) is str, "hostname and username must be provided"

--- a/tests/functional/test_generator.py
+++ b/tests/functional/test_generator.py
@@ -96,14 +96,14 @@ def test_remotegen(n_samples=1000, n_params=2, seed=66):
 
     # run some diagnostics and print results to stderr (so we can see it on CI servers)
     sshdir = os.path.expanduser('~/.ssh/')
-    sys.stderr.write(subprocess.run(['ssh-add', '-l'], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
-    sys.stderr.write(subprocess.run(['ls', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
-    sys.stderr.write(subprocess.run(['cat', os.path.join(sshdir, 'authorized_keys')],
+    sys.stdout.write(subprocess.run(['ssh-add', '-l'], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
+    sys.stdout.write(subprocess.run(['ls', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
+    sys.stdout.write(subprocess.run(['cat', os.path.join(sshdir, 'authorized_keys')],
                                     stdout=subprocess.PIPE).stdout.decode() + '\n\n')
-    sys.stderr.write(subprocess.run(['cat', os.path.join(sshdir, 'known_hosts')],
+    sys.stdout.write(subprocess.run(['cat', os.path.join(sshdir, 'known_hosts')],
                                     stdout=subprocess.PIPE).stdout.decode() + '\n\n')
-    sys.stderr.write(subprocess.run(['ls', '-ld', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
-    sys.stderr.write(subprocess.run(['ls', '-l', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
+    sys.stdout.write(subprocess.run(['ls', '-ld', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
+    sys.stdout.write(subprocess.run(['ls', '-l', sshdir], stdout=subprocess.PIPE).stdout.decode() + '\n\n')
 
     try:
         g = dg.RemoteGenerator(simulator_class=Gauss,


### PR DESCRIPTION
Added a new generator class that creates an MPgenerator on a remote server via ssh and scp and uses it to generate samples. Supports directly running the sample generation on the remote server, or submitting it to a SLURM job manager.