### PR TITLE
remove second dim return on .eval

### DIFF
--- a/delfi/distribution/Gamma.py
+++ b/delfi/distribution/Gamma.py
@@ -41,13 +41,14 @@ class Gamma(BaseDistribution):
     @copy_ancestor_docstring
     def eval(self, x, ii=None, log=True):
         # univariate distribution only, i.e. ii=[0] in any case
-        return self._gamma.logpdf(x-self.offset) if log else self._gamma.pdf(x-self.offset)
+        res = self._gamma.logpdf(x-self.offset) if log else self._gamma.pdf(x-self.offset)
+        return res.squeeze()
 
     @copy_ancestor_docstring
     def gen(self, n_samples=1, seed=None):
         # See BaseDistribution.py for docstring
-        
-        x = self.rng.gamma(shape=self.alpha, 
-                           scale=1./self.beta, 
+
+        x = self.rng.gamma(shape=self.alpha,
+                           scale=1./self.beta,
                            size=(n_samples, self.ndim)) + self.offset
         return x

--- a/delfi/distribution/Gamma.py
+++ b/delfi/distribution/Gamma.py
@@ -41,8 +41,15 @@ class Gamma(BaseDistribution):
     @copy_ancestor_docstring
     def eval(self, x, ii=None, log=True):
         # univariate distribution only, i.e. ii=[0] in any case
+
+        # x should have a second dim with length 1, not more
+        x = np.atleast_2d(x)
+        assert x.shape[1] == 1, f'x needs second dim, {x.shape}'
+        assert not x.ndim > 2, f'no more than 2 dims in x: {x.ndim}'
+
         res = self._gamma.logpdf(x-self.offset) if log else self._gamma.pdf(x-self.offset)
-        return res.squeeze()
+        # reshape to (nbatch, )
+        return res.reshape(-1)
 
     @copy_ancestor_docstring
     def gen(self, n_samples=1, seed=None):

--- a/delfi/distribution/Gaussian.py
+++ b/delfi/distribution/Gaussian.py
@@ -231,7 +231,8 @@ class Gaussian(BaseDistribution):
                 raise ValueError('Rank deficiency in covariance matrix')
 
         res = lp if log else np.exp(lp)
-        return res
+        # make sure nbatch is in first, ndim in second dimension. 
+        return res.reshape(-1, self.ndim)
 
     @copy_ancestor_docstring
     def gen(self, n_samples=1):

--- a/delfi/distribution/Gaussian.py
+++ b/delfi/distribution/Gaussian.py
@@ -231,8 +231,7 @@ class Gaussian(BaseDistribution):
                 raise ValueError('Rank deficiency in covariance matrix')
 
         res = lp if log else np.exp(lp)
-        # make sure nbatch is in first, ndim in second dimension. 
-        return res.reshape(-1, self.ndim)
+        return res
 
     @copy_ancestor_docstring
     def gen(self, n_samples=1):


### PR DESCRIPTION
I noticed that when using an independent joint prior: 
the `Gaussian.eval(...)` returns shape `(nbatch, )` instead of `(nbtach, ndim)` for `ndim=1` and `ii=None`. This should be a quick fix. 