### PR TITLE
numerical stability improvements, add prior precision to posterior gaussian(s), minibatches for validation loss, test updates, bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ install:
   - echo -e "\n[blas]\nldflags = -lopenblas\n" >> ~/.theanorc
   - pip install -r requirements.txt
   - python setup.py install
-script:
   - eval $(ssh-agent -s)
+script:
   - echo $PWD
-  - PYTHONPATH=$PWD:$PYTHONPATH travis_wait pytest --cov=delfi;
+  - PYTHONPATH=$PWD:$PYTHONPATH travis_wait 30 pytest --cov=delfi;
   - travis-sphinx build -n -s docs/
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - python setup.py install
 script:
   - eval $(ssh-agent -s)
-  - PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=delfi;
+  - travis_wait 30 PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=delfi;
   - travis-sphinx build -n -s docs/
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ install:
   - python setup.py install
   - eval $(ssh-agent -s)
 script:
-  - echo $PWD
   - PYTHONPATH=$PWD:$PYTHONPATH travis_wait 30 pytest --cov=delfi;
   - travis-sphinx build -n -s docs/
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ install:
   - python setup.py install
 script:
   - eval $(ssh-agent -s)
-  - travis_wait 30 PYTHONPATH=$PWD:$PYTHONPATH pytest --cov=delfi;
+  - echo $PWD
+  - PYTHONPATH=$PWD:$PYTHONPATH travis_wait pytest --cov=delfi;
   - travis-sphinx build -n -s docs/
 after_success:
   - coveralls

--- a/delfi/inference/APT.py
+++ b/delfi/inference/APT.py
@@ -156,6 +156,7 @@ class APT(BaseInference):
 
     def run(self, n_rounds=1, proposal='gaussian', silent_fail=True, **kwargs):
         """Run algorithm
+
         Parameters
         ----------
         n_train : int or list of ints

--- a/delfi/inference/APT.py
+++ b/delfi/inference/APT.py
@@ -495,6 +495,10 @@ class APT(BaseInference):
 
         return epochs_round
 
+    def reset(self, seed=None):
+        super().reset(seed=seed)
+        self.trn_datasets, self.proposal_used = [], []
+
 
 def MoG_prop_APT_training_vars(prop, n_train_round, n_components):
     if isinstance(prop, dd.Uniform):

--- a/delfi/inference/APT.py
+++ b/delfi/inference/APT.py
@@ -86,17 +86,22 @@ class APT(BaseInference):
         combined_loss : bool
             Whether to include prior likelihood terms in addition to atomic
         """
+        prior = self.generator.prior
+        if isinstance(prior, dd.Gaussian) or isinstance(prior, dd.MoG):
+            prior = prior.ztrans(self.params_mean, self.params_std)
+
         if proposal == 'prior':  # using prior as proposal
             loss, trn_inputs = snpe_loss_prior_as_proposal(self.network,
                                                            svi=self.svi)
         elif proposal == 'gaussian':
             assert isinstance(self.generator.proposal, dd.Gaussian)
             loss, trn_inputs = apt_loss_gaussian_proposal(self.network,
-                                                          self.generator.prior,
+                                                          prior,
                                                           svi=self.svi)
         elif proposal.lower() == 'mog':
+            assert isinstance(self.generator.proposal, dd.MoG)
             loss, trn_inputs = apt_loss_MoG_proposal(self.network,
-                                                     self.generator.prior,
+                                                     prior,
                                                      svi=self.svi)
         elif proposal == 'atomic':
             loss, trn_inputs = \

--- a/delfi/inference/APT.py
+++ b/delfi/inference/APT.py
@@ -125,8 +125,7 @@ class APT(BaseInference):
                                                      add_prior_precision=self.add_prior_precision)
         elif proposal == 'atomic':
             loss, trn_inputs = \
-                apt_loss_atomic_proposal(self.network, svi=self.svi,
-                                         combined_loss=combined_loss)
+                apt_loss_atomic_proposal(self.network, svi=self.svi, combined_loss=combined_loss)
         else:
             raise NotImplemented()
 

--- a/delfi/inference/BaseInference.py
+++ b/delfi/inference/BaseInference.py
@@ -173,8 +173,7 @@ class BaseInference(metaclass=ABCMetaDoc):
             b.set_value(np.zeros_like(b.get_value()))
 
     def conditional_norm(self, fcv=0.8, tmu=None, tSig=None, h=None):
-        """ Normalizes current network output at observed summary statistics
-
+        """Normalizes current network output at observed summary statistics
 
         Parameters
         ----------
@@ -186,7 +185,6 @@ class BaseInference(metaclass=ABCMetaDoc):
             Target mean.
         tSig: array
             Target covariance.
-
         """
 
         # avoid CDELFI.predict() attempt to analytically correct for proposal
@@ -225,7 +223,7 @@ class BaseInference(metaclass=ABCMetaDoc):
 
         # first we need the center of means
         def idx_MoG(x):
-            return x.name[:5]=='means'
+            return x.name[:5] == 'means'
         mu_ = np.zeros_like(mog.xs[0].m)
         for w, b in zip(filter(idx_MoG, self.network.mps_wp),
                         filter(idx_MoG, self.network.mps_bp)):

--- a/delfi/inference/SNPEB.py
+++ b/delfi/inference/SNPEB.py
@@ -4,6 +4,7 @@ from delfi.inference.BaseInference import BaseInference
 from delfi.neuralnet.Trainer import Trainer
 from delfi.neuralnet.loss.regularizer import svi_kl_init, svi_kl_zero
 
+
 class SNPEB(BaseInference):
     def __init__(self, generator, obs, prior_norm=False, pilot_samples=100,
                  convert_to_T=3, reg_lambda=0.01, prior_mixin=0, kernel=None, seed=None, verbose=True,

--- a/delfi/neuralnet/Trainer.py
+++ b/delfi/neuralnet/Trainer.py
@@ -12,7 +12,7 @@ dtype = theano.config.floatX
 
 def block_circulant(x):
     
-    n,d = x.shape
+    n, d = x.shape
     b = x.itemsize
     
     y = as_strided(np.tile(x.flatten(), 2),
@@ -23,10 +23,8 @@ def block_circulant(x):
 
 
 class Trainer:
-    def __init__(self, network, loss, trn_data, trn_inputs,
-                 step=lu.adam, lr=0.001, lr_decay=1.0, max_norm=0.1,
-                 monitor=None, val_frac=0., assemble_extra_inputs=None,
-                 seed=None):
+    def __init__(self, network, loss, trn_data, trn_inputs, step=lu.adam, lr=0.001, lr_decay=1.0, max_norm=0.1,
+                 monitor=None, val_frac=0.0, assemble_extra_inputs=None, seed=None):
         """Construct and configure the trainer
 
         The trainer takes as inputs a neural network, a loss function and
@@ -106,37 +104,34 @@ class Trainer:
 
         self.assemble_extra_inputs = assemble_extra_inputs
 
-        if not (val_frac == 0.):
+        self.do_validation = val_frac > 0
 
-            self.do_validation = True
+        if self.do_validation:
 
             n_trn = int((1 - val_frac) * self.n_trn_data)
-            self.val_data = [ data[n_trn:] for data in trn_data].copy()  # copy() might be overly prudent
-            self.trn_data = [ data[:n_trn] for data in trn_data].copy()
-
-            # assemble extra inputs *once* for validation data
-            if self.assemble_extra_inputs is not None:
-                self.val_data = self.assemble_extra_inputs(tuple(self.val_data))                
-
-            # prepare validation data
-            self.val_inputs = [theano.shared(data.astype(dtype), borrow=True)
-                               for data in self.val_data]
+            self.val_data = [data[n_trn:] for data in trn_data].copy()  # copy() might be overly prudent
+            self.trn_data = [data[:n_trn] for data in trn_data].copy()
 
             # compile theano function for validation
-            self.validate = theano.function(
-                inputs=[],
-                outputs=self.loss,
-                givens=list(zip(self.trn_inputs, self.val_inputs))
-            )
-
+            self.eval_loss = theano.function(inputs=self.trn_inputs, outputs=self.loss)
             self.best_val_loss = np.inf
-
-        else:
-
-            self.do_validation = False
 
         # initialize variables
         self.loss = float('inf')
+
+    def calc_validation_loss(self, minibatch, strict_batch_size):
+        s, L, n_val, n_batches_used = 0, 0.0, self.val_data[0].shape[0], 0.0  # n_batches_used can be fractional
+
+        while s < n_val and (not strict_batch_size or s + minibatch <= n_val):
+            e = np.minimum(s + minibatch, n_val)
+            next_batch = tuple([x[s:e] for x in self.trn_data])
+            if self.assemble_extra_inputs is not None:
+                next_batch = self.assemble_extra_inputs(next_batch)
+            L += self.eval_loss(*next_batch) * (s - e) / minibatch
+            n_batches_used += (s - e) / minibatch
+            s += minibatch
+
+        return L / n_batches_used
 
     def train(self,
               epochs=250,
@@ -185,6 +180,12 @@ class Trainer:
         minibatch = self.n_trn_data if minibatch is None else minibatch
         if minibatch > self.n_trn_data:
             minibatch = self.n_trn_data
+
+        if self.do_validation and strict_batch_size:
+            assert self.val_data[0].shape[0] >= minibatch, "not enough validation samples for a minibatch"
+            if self.val_data[0].shape[0] % minibatch != 0 and verbose:
+                print('{0} validation samples not a multiple of minibatch size {1}, some samples will be wasted'.
+                      format(self.val_data[0].shape[0], minibatch))
 
         maxiter = int(self.n_trn_data / minibatch + 0.5) * epochs
 
@@ -254,7 +255,7 @@ class Trainer:
                         # do validation if we've passed a multiple of monitor_every epochs
                         if iter == 0 or \
                                 np.floor(epoch_frac / monitor_every) != np.floor(prev_epoch_frac / monitor_every):
-                            val_loss = self.validate()
+                            val_loss = self.calc_validation_loss(minibatch, strict_batch_size)
                             trn_outputs['val_loss'].append(val_loss)
                             trn_outputs['val_loss_iter'].append(iter)
                             patience_left -= 1

--- a/delfi/neuralnet/Trainer.py
+++ b/delfi/neuralnet/Trainer.py
@@ -243,6 +243,7 @@ class Trainer:
 
                     # check for nan
                     if stop_on_nan and np.isnan(trn_loss):
+                        print('stopping due to NaN value on iteration {0}\n'.format(iter))
                         break_flag = True
                         break
 

--- a/delfi/neuralnet/Trainer.py
+++ b/delfi/neuralnet/Trainer.py
@@ -111,7 +111,7 @@ class Trainer:
             self.do_validation = True
 
             n_trn = int((1 - val_frac) * self.n_trn_data)
-            self.val_data = [ data[n_trn:] for data in trn_data].copy() # copy() might be  overly prudent
+            self.val_data = [ data[n_trn:] for data in trn_data].copy()  # copy() might be overly prudent
             self.trn_data = [ data[:n_trn] for data in trn_data].copy()
 
             # assemble extra inputs *once* for validation data

--- a/delfi/neuralnet/layers/MixturePrecisions.py
+++ b/delfi/neuralnet/layers/MixturePrecisions.py
@@ -104,8 +104,6 @@ class MixturePrecisionsLayer(lasagne.layers.Layer):
         if not self.rank is None:
             triu_mask[self.rank:] *= 0.
         diag_mask = np.eye(self.n_dim, dtype=dtype)
-        offdiag_mask = np.ones(self.n_dim, dtype=dtype) - \
-            np.eye(self.n_dim, dtype=dtype)
 
         if not self.svi or deterministic:
             zas_reshaped = [tt.reshape(tt.dot(input, mW) + mb, 
@@ -220,8 +218,6 @@ class MixtureHomoscedasticPrecisionsLayer(lasagne.layers.Layer):
         if not self.rank is None:
             triu_mask[self.rank:] *= 0.
         diag_mask = np.eye(self.n_dim, dtype=dtype)
-        offdiag_mask = np.ones(self.n_dim, dtype=dtype) - \
-            np.eye(self.n_dim, dtype=dtype)
 
         if not self.svi or deterministic:
             zas_reshaped = [tt.reshape(mb + 0.*tt.sum(input) , 

--- a/delfi/neuralnet/layers/MixturePrecisions.py
+++ b/delfi/neuralnet/layers/MixturePrecisions.py
@@ -124,23 +124,13 @@ class MixturePrecisionsLayer(lasagne.layers.Layer):
             zas_reshaped = [tt.reshape(
                 za, [-1, self.n_dim, self.n_dim]) for za in zas]
 
-        Us = [
-            triu_mask *
-            za +
-            diag_mask *
-            tt.exp(
-                diag_mask *
-                za) for za in zas_reshaped]
-        ldetUs = [tt.sum(tt.sum(diag_mask * za, axis=2), axis=1)
-                  for za in zas_reshaped]
+        Us = [triu_mask * za + diag_mask * tt.exp(diag_mask * za) for za in zas_reshaped]
+        ldetUs = [tt.sum(tt.sum(diag_mask * za, axis=2), axis=1) for za in zas_reshaped]
 
         # enforce lower bound on diagonal elements of the precision matrices
         if self.min_U_column_norms is not None:
-            U_column_norms = \
-                [tt.sqrt(tt.sum(U**2, axis=1)).reshape((-1, self.n_dim))
-                 for U in Us]
-            scale_factors = [tt.maximum(1.0, self.min_U_column_norms / Ucn)
-                             for Ucn in U_column_norms]
+            U_column_norms = [tt.sqrt(tt.sum(U**2, axis=1)).reshape((-1, self.n_dim)) for U in Us]
+            scale_factors = [tt.maximum(1.0, self.min_U_column_norms / Ucn) for Ucn in U_column_norms]
             Us = [U * sf.dimshuffle([0, 'x', 1]) for U, sf in zip(Us, scale_factors)]
 
         return {'Us': Us, 'ldetUs': ldetUs}

--- a/delfi/neuralnet/loss/lossfunc.py
+++ b/delfi/neuralnet/loss/lossfunc.py
@@ -319,12 +319,10 @@ def apt_loss_atomic_proposal(model, svi=False, combined_loss=False):
     """
 
     if model.density == 'mog':
-        return apt_mdn_loss_atomic_proposal(model, svi=svi,
-                                                combined_loss=combined_loss)
+        return apt_mdn_loss_atomic_proposal(model, svi=svi, combined_loss=combined_loss)
     elif model.density == 'maf':
         assert not svi, 'SVI not supported for MAFs'
-        return apt_maf_loss_atomic_proposal(model, svi=svi,
-                                                combined_loss=combined_loss)
+        return apt_maf_loss_atomic_proposal(model, svi=svi, combined_loss=combined_loss)
 
 
 def apt_mdn_loss_atomic_proposal(mdn, svi=False, combined_loss=False):

--- a/delfi/summarystats/Identity.py
+++ b/delfi/summarystats/Identity.py
@@ -6,9 +6,9 @@ from delfi.summarystats.BaseSummaryStats import BaseSummaryStats
 class Identity(BaseSummaryStats):
     """Just apply the identity instead of reducing data.
     Parameters
-        ----------
-        idx : list or array of int or bool
-            Set of data indices to use us sufficient statistics (None for all).
+    ----------
+    idx : list or array of int or bool
+        Set of data indices to use us sufficient statistics (None for all).
     """
 
     def __init__(self, seed=None, idx=None):

--- a/delfi/utils/symbolic.py
+++ b/delfi/utils/symbolic.py
@@ -1,5 +1,6 @@
 import theano
 import theano.tensor as tt
+import theano.tensor.slinalg as slinalg
 import numpy as np
 
 
@@ -66,6 +67,17 @@ def det_each(A, log=False):
     """
     D = batched_matrix_op(A, tt.nlinalg.Det(), 0)
     return tt.log(D) if log else D
+
+
+def cholesky_each(A):
+    """
+    Calculate cholesky factorizations for a set of positive definite matrices.
+
+    :param A: Array of input matrices. The rows and columns of each matrix must correspond to the last 2 dimensions of
+    A, which must be equal.
+    :return: cholesky factors
+    """
+    return batched_matrix_op(A, slinalg.Cholesky(), 2)
 
 
 def batched_matrix_op(A, Op, Op_output_ndim):

--- a/delfi/utils/symbolic.py
+++ b/delfi/utils/symbolic.py
@@ -80,7 +80,7 @@ def cholesky_each(A):
     return batched_matrix_op(A, slinalg.Cholesky(), 2)
 
 
-def batched_matrix_op(A, Op, Op_output_ndim):
+def batched_matrix_op(A, Op, Op_output_ndim, allow_gc=False):
     """
     Apply a unary operator to a set of matrices stored in an N-D array (N > 2).
     The rows and columns of each matrix must correspond to the last 2
@@ -89,7 +89,7 @@ def batched_matrix_op(A, Op, Op_output_ndim):
     """
     sB = (tt.prod(A.shape[:-2]), A.shape[-2], A.shape[-1])
     B = A.reshape(sB, ndim=3)
-    OpB, _ = theano.scan(fn=lambda X: Op(X), allow_gc=False, sequences=B)
+    OpB, _ = theano.scan(fn=lambda X: Op(X), allow_gc=allow_gc, sequences=B)
     ndim_out = (A.ndim - 2) + Op_output_ndim
     sOpA = tt.join(0, A.shape[:-2], OpB.shape[1:])
     return OpB.reshape(sOpA, ndim=ndim_out)
@@ -125,8 +125,8 @@ def tensorQF(A, x):
 
 def tensorQF_chol(U, x):
     """
-    Symbollicaly evaluate quadratic form with matrix dot(U^T, U) on vector x.
-    This will usually be called on a U resulting from a Cholesky factorzation.
+    Symbolicaly evaluate quadratic form with matrix dot(U^T, U) on vector x.
+    This will usually be called on a U resulting from a Cholesky factorization.
     See tensorQF for further details.
     """
     return tt.sum(tt.sum(x.dimshuffle([0, 'x', 1]) * U, axis=2) ** 2, axis=1)

--- a/docs/api/inference.inc
+++ b/docs/api/inference.inc
@@ -19,7 +19,7 @@ SNPE-A
   :members:
 
 SNPE-B
-````
+``````
 .. autoclass:: delfi.inference.SNPEB
   :show-inheritance:
   :inherited-members:

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -112,7 +112,7 @@ def test_apt_inference_gaussprop(n_params=2, seed=47, Sfac=1000.0):
                                             Sfac=Sfac,
                                             **inf_setup_opts)
     # 3 rounds to test sample reuse. by default prior samples not reused
-    out = res.run(n_train=1000, n_rounds=3, proposal='gaussian',
+    out = res.run(n_train=1500, n_rounds=3, proposal='gaussian',
                   train_on_all=True, silent_fail=False, print_each_epoch=True,
                   reuse_prior_samples=True)
 
@@ -190,7 +190,6 @@ def test_inference_apt_maf_rnn(n_steps=2, dim_per_t=2, seed=42):
 def test_inference_apt_maf_cnn(rows=2, cols=2, seed=42):
     if theano.config.device == 'cpu':
         return  # need a gpu
-
     # we're going to reshape a Gaussian observation to be an image
     # this will test the code but a better test would involve correlated x_i.
     # one option would be to try using a very small blob model

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -98,9 +98,9 @@ def test_apt_inference_mogprop(n_params=2, seed=47):
     res, m_true, S_true = init_all_gaussian(seed=seed, n_params=n_params,
                                             inferenceobj=infer.APT,
                                             **inf_setup_opts)
-    # note that train_on_all is not yet implemented for MoG proposals!
     out = res.run(n_train=3000, n_rounds=2, proposal='mog',
-                  train_on_all=True, silent_fail=False, print_each_epoch=True)
+                  train_on_all=False, silent_fail=False, print_each_epoch=True,
+                  reuse_prior_samples=False)
     posterior = res.predict(res.obs.reshape(1, -1))
     check_gaussian_posterior(posterior, m_true, S_true)
 
@@ -111,7 +111,7 @@ def test_apt_inference_gaussprop(n_params=2, seed=47, Sfac=1000.0):
                                             inferenceobj=infer.APT,
                                             Sfac=Sfac,
                                             **inf_setup_opts)
-    # 3 rounds to test re-use sample reuse. by default prior samples not reused
+    # 3 rounds to test sample reuse. by default prior samples not reused
     out = res.run(n_train=1000, n_rounds=3, proposal='gaussian',
                   train_on_all=True, silent_fail=False, print_each_epoch=True,
                   reuse_prior_samples=True)

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -98,9 +98,9 @@ def test_apt_inference_mogprop(n_params=2, seed=47):
     res, m_true, S_true = init_all_gaussian(seed=seed, n_params=n_params,
                                             inferenceobj=infer.APT,
                                             **inf_setup_opts)
-    out = res.run(n_train=3000, n_rounds=2, proposal='mog',
-                  train_on_all=False, silent_fail=False, print_each_epoch=True,
-                  reuse_prior_samples=False)
+    out = res.run(n_train=1000, n_rounds=2, proposal='mog',
+                  train_on_all=True, silent_fail=False, print_each_epoch=True,
+                  reuse_prior_samples=True)
     posterior = res.predict(res.obs.reshape(1, -1))
     check_gaussian_posterior(posterior, m_true, S_true)
 

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -113,7 +113,8 @@ def test_apt_inference_gaussprop(n_params=2, seed=47, Sfac=1000.0):
                                             **inf_setup_opts)
     # 3 rounds to test re-use sample reuse. by default prior samples not reused
     out = res.run(n_train=1000, n_rounds=3, proposal='gaussian',
-                  train_on_all=True, silent_fail=False, print_each_epoch=True)
+                  train_on_all=True, silent_fail=False, print_each_epoch=True,
+                  reuse_prior_samples=True)
 
     posterior = res.predict(res.obs.reshape(1, -1))
     check_gaussian_posterior(posterior, m_true, S_true, atol_mean=0.05 * np.sqrt(Sfac), atol_cov=0.05 * Sfac)

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -125,8 +125,8 @@ def test_apt_inference_atomicprop_mdn(n_params=2, seed=47):
     res, m_true, S_true = init_all_gaussian(seed=seed, n_params=n_params,
                                             inferenceobj=infer.APT,
                                             **inf_setup_opts)
-    out = res.run(n_train=1000, n_rounds=2, proposal='atomic', n_atoms=10,
-                  train_on_all=True, silent_fail=False, print_each_epoch=True)
+    out = res.run(n_train=1020, n_rounds=2, proposal='atomic', n_atoms=10,
+                  train_on_all=True, silent_fail=False, print_each_epoch=True, verbose=True, val_frac=0.05)
     posterior = res.predict(res.obs.reshape(1, -1))
     check_gaussian_posterior(posterior, m_true, S_true)
 

--- a/tests/unit/test_math.py
+++ b/tests/unit/test_math.py
@@ -1,7 +1,9 @@
 import numpy as np
 import delfi.utils.math as mm
+import delfi.utils.symbolic as sym
 from delfi.distribution import Gaussian
 from delfi.utils.bijection import named_bijection
+import theano
 
 
 def test_gaussprodZ():
@@ -64,3 +66,38 @@ def test_bijections(dim=2, nsamples=1000, seed=1):
         assert np.allclose(x[0], finv(y[0]), atol=1e-8)
         assert np.allclose(f_jac_logD(x), -finv_jac_logD(y), atol=1e-8)
         assert np.allclose(f_jac_logD(x[0]), -finv_jac_logD(y[0]), atol=1e-8)
+
+
+def test_batched_matrix_ops(dim=4, nsamples=100):
+    A_pd = np.full((nsamples, dim, dim), np.nan)
+    A_nonsing = np.full((nsamples, dim, dim), np.nan)
+    L = np.full((nsamples, dim, dim), np.nan)
+    inv = np.full((nsamples, dim, dim), np.nan)
+    det = np.full(nsamples, np.nan)
+    for i in range(nsamples):
+        L[i] = np.tril(np.random.rand(dim, dim), -1) + np.diag(np.exp(np.random.randn(dim)))
+        A_pd[i] = np.dot(L[i], L[i].T)
+        L2 = np.tril(np.random.rand(dim, dim), -1) + np.diag(np.exp(np.random.randn(dim)))
+        L3 = np.tril(np.random.rand(dim, dim), -1) + np.diag(np.exp(np.random.randn(dim)))
+        A_nonsing[i] = np.dot(np.dot(L2, A_pd[i]), L3.T)
+        inv[i] = np.linalg.inv(A_nonsing[i])
+        det[i] = np.linalg.det(A_nonsing[i])
+
+    tA = sym.tensorN(3)
+    f_choleach = theano.function(inputs=[tA], outputs=sym.cholesky_each(tA))
+    f_inveach = theano.function(inputs=[tA], outputs=sym.invert_each(tA))
+    f_deteach = theano.function(inputs=[tA], outputs=sym.det_each(tA))
+
+    symL = f_choleach(A_pd)
+    symdet = f_deteach(A_nonsing)
+    syminv = f_inveach(A_nonsing)
+
+    assert np.allclose(symL, L, atol=1e-8)
+    assert np.allclose(symdet, det, atol=1e-8)
+    assert np.allclose(syminv, inv, atol=1e-8)
+
+    try:
+        f_choleach(A_nonsing)  # try Cholesky factorizing some non-symmetric matrices
+    except Exception as e:
+        assert isinstance(e, np.linalg.linalg.LinAlgError), \
+            "unexpected error when trying Cholesky factorization of non-symmetric matrix"

--- a/tests/unit/test_math.py
+++ b/tests/unit/test_math.py
@@ -1,9 +1,10 @@
 import numpy as np
+import theano
 import delfi.utils.math as mm
 import delfi.utils.symbolic as sym
 from delfi.distribution import Gaussian
 from delfi.utils.bijection import named_bijection
-import theano
+from delfi.neuralnet.NeuralNet import dtype
 
 
 def test_gaussprodZ():
@@ -69,13 +70,13 @@ def test_bijections(dim=2, nsamples=1000, seed=1):
 
 
 def test_batched_matrix_ops(dim=4, nsamples=100):
-    A_pd = np.full((nsamples, dim, dim), np.nan)
-    A_nonsing = np.full((nsamples, dim, dim), np.nan)
-    L = np.full((nsamples, dim, dim), np.nan)
-    inv = np.full((nsamples, dim, dim), np.nan)
-    det = np.full(nsamples, np.nan)
+    A_pd = np.full((nsamples, dim, dim), np.nan, dtype=dtype)
+    A_nonsing = np.full((nsamples, dim, dim), np.nan, dtype=dtype)
+    L = np.full((nsamples, dim, dim), np.nan, dtype=dtype)
+    inv = np.full((nsamples, dim, dim), np.nan, dtype=dtype)
+    det = np.full(nsamples, np.nan, dtype=dtype)
     for i in range(nsamples):
-        L[i] = np.tril(np.random.rand(dim, dim), -1) + np.diag(np.exp(np.random.randn(dim)))
+        L[i] = np.tril(np.random.randn(dim, dim), -1) + np.diag(1.0 + np.exp(np.random.randn(dim)))
         A_pd[i] = np.dot(L[i], L[i].T)
         L2 = np.tril(np.random.rand(dim, dim), -1) + np.diag(np.exp(np.random.randn(dim)))
         L3 = np.tril(np.random.rand(dim, dim), -1) + np.diag(np.exp(np.random.randn(dim)))


### PR DESCRIPTION
*add prior precision to all posterior components for Gauss/MoG proposals
*also add identity times Ptol, with Ptol defaulting to machine epsilon for the relevant data type
*use cholesky factorization to get log determinants of psd matrices
*new tests of symbolic math operations
*fix numerical conditioning in test of APT with Gaussian/MoG proposals
*reuse prior samples when testing APT with Gaussian/MoG proposals
*whitespace, better print statements, cleanup
*fixed bug where prior mean/covariance weren't normalized when prior_norm=True for APT with Gauss or MoG proposals
*use minibatches for validation loss, and use the validation loss in a test