### PR TITLE
add poisson distribution univariate

### DIFF
--- a/delfi/distribution/Poisson.py
+++ b/delfi/distribution/Poisson.py
@@ -36,6 +36,7 @@ class Poisson(BaseDistribution):
     @copy_ancestor_docstring
     def eval(self, x, ii=None, log=True):
         # univariate distribution only, i.e. ii=[0] in any case
+        assert ii is None, 'this is a univariate Poisson, ii must be None.'
 
         # x should have a second dim with length 1, not more
         x = np.atleast_2d(x)

--- a/delfi/distribution/Poisson.py
+++ b/delfi/distribution/Poisson.py
@@ -1,0 +1,54 @@
+import numpy as np 
+from scipy.stats import poisson
+from delfi.distribution.BaseDistribution import BaseDistribution
+
+
+class Poisson(BaseDistribution):
+    def __init__(self, mu=0., offset=0., seed=None):
+        """Univariate (!) Poisson distribution
+        Parameters
+        ----------
+        mu: shape parameter of the Poisson (Poisson rate)
+        offset: shift in the mean parameter, see scipy.stats.Poisson documentation. 
+        seed : int or None
+            If provided, random number generator will be seeded
+        """
+        super().__init__(ndim=1, seed=seed)
+        
+        mu = np.atleast_1d(mu)
+        assert mu.ndim == 1, 'mu must be a 1-d array'
+        assert offset >= 0, 'offset must not be negative'
+        
+        self.mu = mu
+        self.offset = offset
+        self._poisson = poisson(mu=mu, loc=offset)
+
+    @property
+    def mean(self):
+        """Means"""
+        return self.mu
+
+    @property
+    def std(self):
+        """Standard deviations of marginals"""
+        return np.sqrt(self.mu)
+
+    @copy_ancestor_docstring
+    def eval(self, x, ii=None, log=True):
+        # univariate distribution only, i.e. ii=[0] in any case
+
+        # x should have a second dim with length 1, not more
+        x = np.atleast_2d(x)
+        assert x.shape[1] == 1, 'x needs second dim'
+        assert not x.ndim > 2, 'no more than 2 dims in x'
+
+        res = self._poisson.logpmf(x) if log else self._poisson.pmf(x)
+        # reshape to (nbatch, )
+        return res.reshape(-1)
+
+    @copy_ancestor_docstring
+    def gen(self, n_samples=1, seed=None):
+        # See BaseDistribution.py for docstring
+
+        x = self._poisson.rvs(random_state=self.rng, size=(n_samples, self.ndim))
+        return x

--- a/delfi/distribution/__init__.py
+++ b/delfi/distribution/__init__.py
@@ -4,6 +4,7 @@ from delfi.distribution.TransformedNormal import TransformedNormal
 from delfi.distribution.StudentsT import StudentsT
 from delfi.distribution.Uniform import Uniform
 from delfi.distribution.Gamma import Gamma
+from delfi.distribution.Poisson import Poisson
 from delfi.distribution.Logistic import Logistic
 from delfi.distribution.IndependentJoint import IndependentJoint
 from delfi.distribution.TransformedDistribution import TransformedDistribution

--- a/tests/unit/test_distribution.py
+++ b/tests/unit/test_distribution.py
@@ -47,6 +47,19 @@ def test_gaussian_3d():
     assert np.allclose(np.cov(samples, rowvar=False), S, atol=0.1)
 
 
+def test_poisson(): 
+    N = 50000
+    mu = 5.
+    offset = 1. 
+    dist = dd.Poisson(mu=mu, offset=offset)
+    samples = dist.gen(N)
+    logprobs = dist.eval(samples)
+    
+    assert samples.shape == (N, 1)
+    assert logprobs.shape == (N,)
+    assert np.allclose(np.mean(samples, axis=0), mu + offset, atol=0.1)
+     
+
 def test_studentst_1d():
     N = 100000
     m = [1.]


### PR DESCRIPTION
note that in line [53](https://github.com/janfb/delfi/blob/add_poisson/delfi/distribution/Poisson.py#L53) 

```x = self._poisson.rvs(random_state=self.rng, size=(n_samples, self.ndim))```

I use `self._poisson` which is the scipy Poisson, and not the `self.rng.poisson` (as in [`delfi/distribution/Gamma.py`](https://github.com/janfb/delfi/blob/add_poisson/delfi/distribution/Gamma.py#L58)) which would be numpy. For seeding I pass `self.rng`as the `random_state`.  
